### PR TITLE
fix: restore bottom tabs, filter position, and broken icons on Android

### DIFF
--- a/src/components/DeviceStatusCard.tsx
+++ b/src/components/DeviceStatusCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { View, Text, StyleSheet } from 'react-native'
-import { Image } from 'expo-image'
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons'
 
 interface StatusItemProps {
     label: string
@@ -22,14 +22,14 @@ const StatusItem: React.FC<StatusItemProps> = ({ label, value, status, icon }) =
     return (
         <View style={styles.itemContainer}>
             <View style={styles.labelContainer}>
-                {icon && <Image source={icon} style={[styles.baseIcon, styles.iconNeutral, styles.icon]} />}
+                {icon && <MaterialCommunityIcons name={icon as any} size={16} color="#666" style={styles.icon} />}
                 <Text style={styles.label}>{label}</Text>
             </View>
             <View style={styles.valueContainer}>
                 <Text style={[styles.value, { color: getStatusColor() }]}>{value}</Text>
-                {status === 'success' && <Image source="sf:checkmark.circle.fill" style={[styles.baseIcon, styles.iconSuccess, styles.statusIcon]} />}
-                {status === 'error' && <Image source="sf:exclamationmark.circle.fill" style={[styles.baseIcon, styles.iconError, styles.statusIcon]} />}
-                {status === 'warning' && <Image source="sf:exclamationmark.triangle.fill" style={[styles.baseIcon, styles.iconWarning, styles.statusIcon]} />}
+                {status === 'success' && <MaterialCommunityIcons name="check-circle" size={16} color="#4CAF50" style={styles.statusIcon} />}
+                {status === 'error' && <MaterialCommunityIcons name="alert-circle" size={16} color="#F44336" style={styles.statusIcon} />}
+                {status === 'warning' && <MaterialCommunityIcons name="alert" size={16} color="#FFC107" style={styles.statusIcon} />}
             </View>
         </View>
     )
@@ -92,35 +92,35 @@ export const DeviceStatusCard: React.FC<DeviceStatusCardProps> = ({
                 label="Battery"
                 value={batteryLevel ? `${batteryLevel}% (${batteryVoltage || '?'}mV)` : 'Unknown'}
                 status={getBatteryStatus()}
-                icon="sf:battery.100.bolt"
+                icon="battery-charging-100"
             />
 
             <StatusItem
                 label="SD Card"
                 value={sdCardTotal ? `${formatBytes(sdCardAvailable)} / ${formatBytes(sdCardTotal)} free` : 'Not Detected'}
                 status={getSdCardStatus()}
-                icon="sf:externaldrive.fill"
+                icon="harddisk"
             />
 
             <StatusItem
                 label="Firmware"
                 value={firmwareVersion || 'Unknown'}
                 status={firmwareVersion ? 'neutral' : 'warning'}
-                icon="sf:cpu"
+                icon="cpu-64-bit"
             />
 
             <StatusItem
                 label="AI Model"
                 value={aiModelVersion || 'Unknown'}
                 status={aiModelVersion ? 'neutral' : 'warning'}
-                icon="sf:eye.fill"
+                icon="eye"
             />
 
             <StatusItem
                 label="LoRaWAN"
                 value={lorawanStatus ? `RSSI: ${lorawanStatus.rssi}, SNR: ${lorawanStatus.snr}` : 'Not Tested'}
                 status={getLorawanStatus()}
-                icon="sf:antenna.radiowaves.left.and.right"
+                icon="antenna"
             />
         </View>
     )

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -12,7 +12,7 @@
 import { appSchema, tableSchema } from '@nozbe/watermelondb'
 
 export default appSchema({
-    version: 198,
+    version: 199,
     tables: [
         tableSchema({
             name: 'activity_sensitivity',

--- a/src/features/maps/components/DeploymentCard.tsx
+++ b/src/features/maps/components/DeploymentCard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native'
 import Animated, { useSharedValue, useAnimatedStyle, withSpring, withTiming } from 'react-native-reanimated'
-import { Image } from 'expo-image'
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons'
 import { useExtendedTheme } from '../../../theme'
 import type Deployment from '../../../database/models/Deployment'
 
@@ -42,10 +42,10 @@ export const DeploymentCard: React.FC<Props> = ({ deployment, isVisible, onClose
     // Status helper (duplicated from MapScreen, could be shared util)
     const getStatusInfo = (statusId?: number | null) => {
         switch (statusId) {
-            case 1: return { label: 'Active', color: '#4CAF50', icon: 'sf:checkmark.circle.fill' }
-            case 2: return { label: 'Ended', color: '#616161', icon: 'sf:stop.circle.fill' }
-            case 3: return { label: 'Failed', color: '#F44336', icon: 'sf:exclamationmark.circle.fill' }
-            default: return { label: 'Unknown', color: '#757575', icon: 'sf:questionmark.circle.fill' }
+            case 1: return { label: 'Active', color: '#4CAF50', icon: 'check-circle' as const }
+            case 2: return { label: 'Ended', color: '#616161', icon: 'stop-circle' as const }
+            case 3: return { label: 'Failed', color: '#F44336', icon: 'alert-circle' as const }
+            default: return { label: 'Unknown', color: '#757575', icon: 'help-circle' as const }
         }
     }
 
@@ -71,20 +71,20 @@ export const DeploymentCard: React.FC<Props> = ({ deployment, isVisible, onClose
                             {deployment?.name || 'Unnamed Deployment'}
                         </Text>
                         <View style={styles.statusRow}>
-                            <Image source={statusObj.icon} style={[styles.iconSmall, { tintColor: statusObj.color }]} />
+                            <MaterialCommunityIcons name={statusObj.icon} size={14} color={statusObj.color} />
                             <Text style={[styles.statusText, { color: statusObj.color }]}>
                                 {statusObj.label}
                             </Text>
                         </View>
                     </View>
                     <TouchableOpacity onPress={onClose} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-                        <Image source="sf:xmark" style={[styles.iconLarge, { tintColor: colors.onSurfaceVariant }]} />
+                        <MaterialCommunityIcons name="close" size={24} color={colors.onSurfaceVariant} />
                     </TouchableOpacity>
                 </View>
 
                 {deployment?.locationName && (
                     <View style={styles.locationRow}>
-                        <Image source="sf:mappin.and.ellipse" style={[styles.iconMedium, { tintColor: colors.onSurfaceVariant }]} />
+                        <MaterialCommunityIcons name="map-marker" size={16} color={colors.onSurfaceVariant} />
                         <Text style={[styles.locationText, { color: colors.onSurfaceVariant }]}>
                             {deployment.locationName}
                         </Text>
@@ -96,7 +96,7 @@ export const DeploymentCard: React.FC<Props> = ({ deployment, isVisible, onClose
                     onPress={onPress}
                 >
                     <Text style={[styles.buttonText, { color: colors.onPrimary }]}>View Details</Text>
-                    <Image source="sf:arrow.right" style={[styles.iconMedium, { tintColor: colors.onPrimary }]} />
+                    <MaterialCommunityIcons name="arrow-right" size={16} color={colors.onPrimary} />
                 </TouchableOpacity>
             </View>
         </Animated.View>

--- a/src/features/maps/components/DeploymentMarker.tsx
+++ b/src/features/maps/components/DeploymentMarker.tsx
@@ -2,7 +2,7 @@
 import React, { useRef, useLayoutEffect, useState, memo } from 'react'
 import { View, StyleSheet } from 'react-native'
 import { Marker } from 'react-native-maps'
-import { Image } from 'expo-image'
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons'
 import type Deployment from '../../../database/models/Deployment'
 
 interface Props {
@@ -54,7 +54,7 @@ const DeploymentMarkerComponent: React.FC<Props> = ({ deployment, onPress }) => 
             tracksInfoWindowChanges={false} // We don't use InfoWindow/Callout
         >
             <View style={[styles.markerBody, { borderColor: color }]}>
-                <Image source="sf:camera.fill" style={[styles.icon, { tintColor: color }]} />
+                <MaterialCommunityIcons name="camera" size={20} color={color} />
             </View>
         </Marker>
     )

--- a/src/features/maps/screens/MapScreen.tsx
+++ b/src/features/maps/screens/MapScreen.tsx
@@ -364,6 +364,7 @@ const styles = StyleSheet.create({
 		backgroundColor: "rgba(255, 255, 255, 0.9)",
 	},
 	filterFab: {
+		position: "absolute",
 		right: 16, // Move to right to balance with Menu button
 	},
 	centerFab: {

--- a/src/screens/Devices/DevicePreparationScreen.tsx
+++ b/src/screens/Devices/DevicePreparationScreen.tsx
@@ -3,7 +3,7 @@ import { View, Text, ScrollView, StyleSheet, TouchableOpacity, ActivityIndicator
 import { useNavigation, useRoute } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { RootStackParamList } from '../../navigation/types'
-import { Image } from 'expo-image'
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons'
 import { useAppSelector } from '../../redux'
 import { useBle } from '../../hooks/useBle'
 import { useBleCommands } from '../../hooks/useBleCommands'
@@ -195,7 +195,7 @@ export const DevicePreparationScreen = () => {
 
                 {!preparationId ? (
                     <TouchableOpacity style={styles.actionButton} onPress={startWorkflow}>
-                        <Image source="sf:play.fill" style={[styles.iconWhite, styles.actionIcon]} />
+                        <MaterialCommunityIcons name="play" size={20} color="#FFF" style={styles.actionIcon} />
                         <Text style={styles.actionButtonText}>Start New Preparation</Text>
                     </TouchableOpacity>
                 ) : (
@@ -205,7 +205,7 @@ export const DevicePreparationScreen = () => {
                             onPress={runAllChecks}
                             disabled={!device.connected}
                         >
-                            <Image source="sf:arrow.clockwise" style={[styles.iconWhite, styles.actionIcon]} />
+                            <MaterialCommunityIcons name="refresh" size={20} color="#FFF" style={styles.actionIcon} />
                             <Text style={styles.actionButtonText}>Run Health Checks</Text>
                         </TouchableOpacity>
 
@@ -213,7 +213,7 @@ export const DevicePreparationScreen = () => {
                             style={[styles.actionButton, styles.secondaryButton]}
                             onPress={() => navigation.navigate('EngineerConsoleScreen', { deviceId })}
                         >
-                            <Image source="sf:terminal.fill" style={[styles.iconBlue, styles.actionIcon]} />
+                            <MaterialCommunityIcons name="console" size={20} color="#2196F3" style={styles.actionIcon} />
                             <Text style={[styles.actionButtonText, styles.secondaryButtonText]}>Open Engineer Console</Text>
                         </TouchableOpacity>
                     </>

--- a/src/screens/Devices/components/ConsoleInput.tsx
+++ b/src/screens/Devices/components/ConsoleInput.tsx
@@ -1,6 +1,6 @@
 
 import { View, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
-import { Image } from 'expo-image';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { KeyboardStickyView } from "react-native-keyboard-controller";
 
 interface ConsoleInputProps {
@@ -36,7 +36,7 @@ export const ConsoleInput = ({
                     onPress={onSend}
                     disabled={isSendDisabled}
                 >
-                    <Image source="sf:paperplane.fill" style={styles.iconStyles} />
+                    <MaterialCommunityIcons name="send" size={20} color="#FFF" />
                 </TouchableOpacity>
             </View>
         </KeyboardStickyView>


### PR DESCRIPTION
- Add missing position:absolute to filterFab on MapScreen (fixes both filter placement and bottom tabs being pushed off-screen)
- Replace expo-image SF Symbol icons with MaterialCommunityIcons (SF Symbols are iOS-only, rendered as blank on Android)
- Affected files: MapScreen, DeploymentMarker, DeploymentCard, DeviceStatusCard, DevicePreparationScreen, ConsoleInput