### PR TITLE
fix: replace dynamic require with static import for ProjectService

### DIFF
--- a/src/services/DeploymentService.ts
+++ b/src/services/DeploymentService.ts
@@ -4,6 +4,7 @@ import database from '../database'
 import Deployment from '../database/models/Deployment'
 import OutboxService from './OutboxService'
 import SupabaseSyncService from './SupabaseSyncService'
+import ProjectService from './ProjectService'
 import { log, logError, logWarn } from '../utils/logger'
 
 
@@ -43,8 +44,7 @@ export const DeploymentService = {
         log('[DeploymentService] Creating deployment:', data.name)
 
         // Fetch Project Settings for Snapshot
-        const projectService = require('./ProjectService').default // Dynamic import to avoid cycles if any
-        const project = await projectService.getProjectById(data.projectId)
+        const project = await ProjectService.getProjectById(data.projectId)
         const sensitivityId = project?.activity_detection_sensitivity_id
         const timelapseInterval = project?.timelapse_interval_seconds
 
@@ -287,7 +287,6 @@ export const DeploymentService = {
      * Get deployments that the user has access to
      */
     getDeploymentsForUser: async (userId: string): Promise<Deployment[]> => {
-        const ProjectService = require('./ProjectService').default
         const userProjects = await ProjectService.getProjectsForUser(userId)
         const projectIds = new Set(userProjects.map((p: any) => p.id))
 
@@ -318,7 +317,6 @@ export const DeploymentService = {
      * Get deployments for user in a specific organisation
      */
     getDeploymentsForUserInOrganisation: async (userId: string, organisationId: string): Promise<Deployment[]> => {
-        const ProjectService = require('./ProjectService').default
         const userProjects = await ProjectService.getProjectsForUserInOrganisation(userId, organisationId)
         const projectIds = new Set(userProjects.map((p: any) => p.id))
 


### PR DESCRIPTION
Fixes an issue where DeploymentsListScreen was empty in staging/production builds (Hermes). The dynamic \
equire('./ProjectService').default\ evaluated to undefined in these environments, throwing an error and preventing the local deployments from populating the list.