### PR TITLE
feat: add Himax AI firmware update from SD card via BLE

### DIFF
--- a/src/ble/types.ts
+++ b/src/ble/types.ts
@@ -46,6 +46,7 @@ export enum CommandNames {
 	md = "md",
 	setdid = "setdid",
 	getdid = "getdid",
+	ai_firmware = "ai_firmware",
 
 	// Process commands (UPPERCASE - app-specific workflows)
 	SET_UTC = "SET_UTC",
@@ -61,6 +62,7 @@ export enum CommandNames {
 	TX_FILE = "TX_FILE",
 	CAPTURE_PREVIEW = "CAPTURE_PREVIEW",
 	UPDATE_BLE_FIRMWARE = "UPDATE_BLE_FIRMWARE",
+	UPDATE_HIMAX_FIRMWARE = "UPDATE_HIMAX_FIRMWARE",
 	MOTION_DETECTION_PREVIEW = "MOTION_DETECTION_PREVIEW",
 	CAMERA_SETTINGS_TEST = "CAMERA_SETTINGS_TEST",
 
@@ -401,8 +403,17 @@ export const COMMANDS: {
 	[CommandNames.ai_ver]: {
 		name: CommandNames.ai_ver,
 		readCommand: "AI ver",
+		readRegex: /V\s*(\d+\.\d+\.\d+(?:-[\w.-]+)?)/i,
 		description: "Get AI processor version",
 		type: 'command',
+	},
+	[CommandNames.ai_firmware]: {
+		name: CommandNames.ai_firmware,
+		writeCommand: (filename?: string) => `AI firmware ${filename || 'output.img'}`,
+		readRegex: /Firmware update (OK|FAILED)/i,
+		description: "Update Himax firmware from SD card image",
+		type: 'command',
+		timeout: 120000,
 	},
 	[CommandNames.erasemodel]: {
 		name: CommandNames.erasemodel,
@@ -580,6 +591,11 @@ export const COMMANDS: {
 	[CommandNames.UPDATE_BLE_FIRMWARE]: {
 		name: CommandNames.UPDATE_BLE_FIRMWARE,
 		description: "Update BLE Firmware (DFU)",
+		type: 'process',
+	},
+	[CommandNames.UPDATE_HIMAX_FIRMWARE]: {
+		name: CommandNames.UPDATE_HIMAX_FIRMWARE,
+		description: "Update Himax Firmware from SD Card",
 		type: 'process',
 	},
 	[CommandNames.MOTION_DETECTION_PREVIEW]: {

--- a/src/ble/types.ts
+++ b/src/ble/types.ts
@@ -413,7 +413,6 @@ export const COMMANDS: {
 		readRegex: /Firmware update (OK|FAILED)/i,
 		description: "Update Himax firmware from SD card image",
 		type: 'command',
-		timeout: 120000,
 	},
 	[CommandNames.erasemodel]: {
 		name: CommandNames.erasemodel,

--- a/src/hooks/useBleCommands.ts
+++ b/src/hooks/useBleCommands.ts
@@ -26,6 +26,8 @@ export const useBleCommands = () => {
     const runDfu = useMemo(() => createAction(write, CommandNames.dfu), [write])
     const runReset = useMemo(() => createAction(write, CommandNames.reset), [write])
     const runErase = useMemo(() => createAction(write, CommandNames.erase), [write])
+    const updateHimaxFirmware = useMemo(() => createCommand(write, CommandNames.ai_firmware, { timeout: 120000 }), [write])
+    const getHimaxVersion = useMemo(() => createCommand(write, CommandNames.ai_ver, { timeout: 10000 }), [write])
 
     const runDisconnect = useCallback(async (peripheral: ExtendedPeripheral) => {
         try {
@@ -279,5 +281,8 @@ export const useBleCommands = () => {
         getOrFetchOperationalParams,
         setGpsLocation,
         clearGpsLocation,
+        // Himax
+        updateHimaxFirmware,
+        getHimaxVersion,
     }
 }

--- a/src/hooks/useBleCommands.ts
+++ b/src/hooks/useBleCommands.ts
@@ -26,8 +26,7 @@ export const useBleCommands = () => {
     const runDfu = useMemo(() => createAction(write, CommandNames.dfu), [write])
     const runReset = useMemo(() => createAction(write, CommandNames.reset), [write])
     const runErase = useMemo(() => createAction(write, CommandNames.erase), [write])
-    const updateHimaxFirmware = useMemo(() => createCommand(write, CommandNames.ai_firmware, { timeout: 120000 }), [write])
-    const getHimaxVersion = useMemo(() => createCommand(write, CommandNames.ai_ver, { timeout: 10000 }), [write])
+    const updateHimaxFirmware = useMemo(() => createCommand(write, CommandNames.ai_firmware), [write])
 
     const runDisconnect = useCallback(async (peripheral: ExtendedPeripheral) => {
         try {
@@ -283,6 +282,5 @@ export const useBleCommands = () => {
         clearGpsLocation,
         // Himax
         updateHimaxFirmware,
-        getHimaxVersion,
     }
 }

--- a/src/screens/Deployments/StartMonitoringScreen.tsx
+++ b/src/screens/Deployments/StartMonitoringScreen.tsx
@@ -49,7 +49,10 @@ export const StartMonitoringDetailsStep = () => {
         bleFirmwareUpdateAvailable, firmwareUpdateProgress, isUpdatingFirmware,
         isCheckingFirmware, isVerifyingUpdate, firmwareUpdateStatus,
         handleBatteryCheck, handleSdCardCheck, handleFirmwareCheck, handleBleFirmwareUpdate,
-        isMonitoring, handleMonitorDisconnect
+        isMonitoring, handleMonitorDisconnect,
+        // Himax Firmware
+        himaxFirmwareVersion, isHimaxUpdating, himaxUpdateProgress, isCheckingHimaxVersion,
+        handleHimaxFirmwareCheck, handleHimaxFirmwareUpdate
     } = useStartDeployment({ deviceId, bleDeviceId, projectId, navigation, initPayload })
 
     useEffect(() => {
@@ -237,6 +240,12 @@ export const StartMonitoringDetailsStep = () => {
                     handleSdCardCheck={handleSdCardCheck}
                     handleFirmwareCheck={handleFirmwareCheck}
                     handleBleFirmwareUpdate={handleBleFirmwareUpdate}
+                    himaxFirmwareVersion={himaxFirmwareVersion}
+                    isHimaxUpdating={isHimaxUpdating}
+                    himaxUpdateProgress={himaxUpdateProgress}
+                    isCheckingHimaxVersion={isCheckingHimaxVersion}
+                    handleHimaxFirmwareCheck={handleHimaxFirmwareCheck}
+                    handleHimaxFirmwareUpdate={handleHimaxFirmwareUpdate}
                     isInitializing={isInitializing}
                     bleDeviceConnected={!!bleDevice?.connected}
                     theme={theme}

--- a/src/screens/Deployments/components/AdvancedSettingsSection.tsx
+++ b/src/screens/Deployments/components/AdvancedSettingsSection.tsx
@@ -31,6 +31,13 @@ interface AdvancedSettingsSectionProps {
     handleSdCardCheck: () => void
     handleFirmwareCheck: () => void
     handleBleFirmwareUpdate: () => void
+    // Himax Firmware
+    himaxFirmwareVersion: string | null
+    isHimaxUpdating: boolean
+    himaxUpdateProgress: string
+    isCheckingHimaxVersion: boolean
+    handleHimaxFirmwareCheck: () => void
+    handleHimaxFirmwareUpdate: () => void
     isInitializing: boolean
     bleDeviceConnected: boolean
     theme: any
@@ -59,6 +66,13 @@ export const AdvancedSettingsSection: React.FC<AdvancedSettingsSectionProps> = (
     handleSdCardCheck,
     handleFirmwareCheck,
     handleBleFirmwareUpdate,
+    // Himax Firmware
+    himaxFirmwareVersion,
+    isHimaxUpdating,
+    himaxUpdateProgress,
+    isCheckingHimaxVersion,
+    handleHimaxFirmwareCheck,
+    handleHimaxFirmwareUpdate,
     isInitializing,
     bleDeviceConnected,
     theme,
@@ -107,6 +121,17 @@ export const AdvancedSettingsSection: React.FC<AdvancedSettingsSectionProps> = (
             {...props} 
             icon="help-circle-outline" 
             onPress={() => onShowHelp('Location & Camera Settings', 'Site Name: Name of the monitoring site.\n\nCamera Height: The height of the camera lens from the ground in centimeters.')}
+        >
+            <Text>Help</Text>
+        </Button>
+    ), [onShowHelp])
+
+
+    const renderHimaxFirmwareHelp = useCallback((props: any) => (
+        <Button 
+            {...props} 
+            icon="help-circle-outline" 
+            onPress={() => onShowHelp('Himax Firmware', 'The AI processor (Himax WE2) firmware. To update, place the output.img file in the /MANIFEST/ folder on the SD card, then press Update.')}
         >
             <Text>Help</Text>
         </Button>
@@ -311,6 +336,68 @@ export const AdvancedSettingsSection: React.FC<AdvancedSettingsSectionProps> = (
                                 <WWButton
                                     mode="outlined"
                                     onPress={handleFirmwareCheck}
+                                    disabled={isInitializing || !bleDeviceConnected}
+                                    style={styles.actionButton}
+                                >
+                                    <Text>Refresh Version</Text>
+                                </WWButton>
+                            </View>
+                        ) : null}
+                    </Card.Content>
+                </Card>
+
+                {/* Himax Firmware Card */}
+                <Card style={styles.card}>
+                    <Card.Title
+                        title="Himax AI Firmware"
+                        right={renderHimaxFirmwareHelp}
+                    />
+                    <Card.Content>
+                        {himaxFirmwareVersion && (
+                            <WWText style={styles.firmwareVersionText}>
+                                <Text>AI Processor Version: {himaxFirmwareVersion}</Text>
+                            </WWText>
+                        )}
+
+                        {!himaxFirmwareVersion && !isCheckingHimaxVersion && (
+                            <WWButton
+                                mode="outlined"
+                                onPress={handleHimaxFirmwareCheck}
+                                disabled={isInitializing || !bleDeviceConnected}
+                                style={styles.actionButton}
+                            >
+                                <Text>Check AI Firmware Version</Text>
+                            </WWButton>
+                        )}
+
+                        {isCheckingHimaxVersion && (
+                            <WWText variant="bodySmall" style={styles.statusHint}>
+                                <Text>Checking AI firmware version...</Text>
+                            </WWText>
+                        )}
+
+                        {isHimaxUpdating ? (
+                            <View style={styles.updatingContainer}>
+                                <WWText variant="bodyMedium">
+                                    <Text>🔄 {himaxUpdateProgress || 'Updating...'}</Text>
+                                </WWText>
+                                <WWText variant="bodySmall" style={styles.statusHint}>
+                                    <Text>Do not disconnect the device or remove the SD card...</Text>
+                                </WWText>
+                            </View>
+                        ) : himaxFirmwareVersion ? (
+                            <View>
+                                <WWButton
+                                    mode="outlined"
+                                    onPress={handleHimaxFirmwareUpdate}
+                                    disabled={isInitializing || !bleDeviceConnected}
+                                    style={styles.actionButton}
+                                >
+                                    <Text>Flash Firmware from SD Card</Text>
+                                </WWButton>
+                                <WWButton
+                                    mode="text"
+                                    onPress={handleHimaxFirmwareCheck}
                                     disabled={isInitializing || !bleDeviceConnected}
                                     style={styles.actionButton}
                                 >

--- a/src/screens/Deployments/hooks/useStartDeployment.ts
+++ b/src/screens/Deployments/hooks/useStartDeployment.ts
@@ -130,7 +130,7 @@ export const useStartDeployment = ({
 
     // BLE Hooks
     const { connectDevice } = useBle()
-    const { setUtc, runDisconnect, getBatteryLevel, checkSdCard, getDeviceVer, runSelfTest, runDfu, runReset, pingNetwork, getLorawanMetrics, getHimaxVersion, updateHimaxFirmware } = useBleCommands()
+    const { setUtc, runDisconnect, getBatteryLevel, checkSdCard, getDeviceVer, runSelfTest, runDfu, runReset, pingNetwork, getLorawanMetrics, getAiVer, updateHimaxFirmware } = useBleCommands()
     // const { initialize } = useBleInitialization()
     const { configure: startConfigure } = useDeploymentConfiguration()
     useBleActions()
@@ -842,9 +842,9 @@ export const useStartDeployment = ({
         if (!bleDevice || !bleDevice.connected) return
         try {
             setIsCheckingHimaxVersion(true)
-            const response = await getHimaxVersion(bleDevice)
+            const response = await getAiVer(bleDevice)
             if (response) {
-                const match = response.match(/V\s*(\d+\.\d+\.\d+(?:-[\w.-]+)?)/i)
+                const match = response.match(COMMANDS[CommandNames.ai_ver].readRegex!)
                 if (match) {
                     setHimaxFirmwareVersion(match[1])
                     log('[Deployment] Himax firmware version:', match[1])
@@ -859,7 +859,7 @@ export const useStartDeployment = ({
         } finally {
             setIsCheckingHimaxVersion(false)
         }
-    }, [bleDevice, getHimaxVersion])
+    }, [bleDevice, getAiVer])
 
     const handleHimaxFirmwareUpdate = useCallback(async () => {
         if (!bleDevice || !bleDevice.connected) return
@@ -883,13 +883,15 @@ export const useStartDeployment = ({
 
                             const response = await updateHimaxFirmware(bleDevice)
 
-                            if (response && /FAILED/i.test(response)) {
+                            const match = response ? response.match(COMMANDS[CommandNames.ai_firmware].readRegex!) : null
+
+                            if (match && match[1].toUpperCase() === 'FAILED') {
                                 const errorMatch = response.match(/error\s+(-?\d+)/i)
                                 const errorCode = errorMatch ? errorMatch[1] : 'unknown'
                                 throw new Error(`Firmware update failed on device (error ${errorCode}). Existing firmware unchanged.`)
                             }
 
-                            if (response && /OK/i.test(response)) {
+                            if (match && match[1].toUpperCase() === 'OK') {
                                 setHimaxUpdateProgress('Firmware flashed! Sending reset...')
 
                                 try {

--- a/src/screens/Deployments/hooks/useStartDeployment.ts
+++ b/src/screens/Deployments/hooks/useStartDeployment.ts
@@ -130,7 +130,7 @@ export const useStartDeployment = ({
 
     // BLE Hooks
     const { connectDevice } = useBle()
-    const { setUtc, runDisconnect, getBatteryLevel, checkSdCard, getDeviceVer, runSelfTest, runDfu, pingNetwork, getLorawanMetrics } = useBleCommands()
+    const { setUtc, runDisconnect, getBatteryLevel, checkSdCard, getDeviceVer, runSelfTest, runDfu, runReset, pingNetwork, getLorawanMetrics, getHimaxVersion, updateHimaxFirmware } = useBleCommands()
     // const { initialize } = useBleInitialization()
     const { configure: startConfigure } = useDeploymentConfiguration()
     useBleActions()
@@ -153,6 +153,12 @@ export const useStartDeployment = ({
     // Refs for DFU
     const isDfuInProgress = useRef(false)
     const isReconnectingAfterDfu = useRef(false)
+
+    // Himax Firmware State
+    const [himaxFirmwareVersion, setHimaxFirmwareVersion] = useState<string | null>(null)
+    const [isHimaxUpdating, setIsHimaxUpdating] = useState(false)
+    const [himaxUpdateProgress, setHimaxUpdateProgress] = useState('')
+    const [isCheckingHimaxVersion, setIsCheckingHimaxVersion] = useState(false)
 
     const [formState, setFormState] = useState({
         notes: '',
@@ -830,6 +836,117 @@ export const useStartDeployment = ({
         )
     }, [latestBleFirmware, device, bleDevice, bleDeviceId, batteryLevel, handleFirmwareCheck, runDisconnect, runDfu, connectDevice, navigation])
 
+    // --- Himax Firmware Handlers ---
+
+    const handleHimaxFirmwareCheck = useCallback(async () => {
+        if (!bleDevice || !bleDevice.connected) return
+        try {
+            setIsCheckingHimaxVersion(true)
+            const response = await getHimaxVersion(bleDevice)
+            if (response) {
+                const match = response.match(/V\s*(\d+\.\d+\.\d+(?:-[\w.-]+)?)/i)
+                if (match) {
+                    setHimaxFirmwareVersion(match[1])
+                    log('[Deployment] Himax firmware version:', match[1])
+                } else {
+                    // Use raw response if no version pattern found
+                    setHimaxFirmwareVersion(response.trim())
+                }
+            }
+        } catch (error) {
+            logError('[Deployment] Himax version check failed:', error)
+            Alert.alert('Error', 'Failed to check Himax firmware version')
+        } finally {
+            setIsCheckingHimaxVersion(false)
+        }
+    }, [bleDevice, getHimaxVersion])
+
+    const handleHimaxFirmwareUpdate = useCallback(async () => {
+        if (!bleDevice || !bleDevice.connected) return
+
+        const isLowBattery = batteryLevel !== null && batteryLevel < 30
+        const batteryWarning = isLowBattery
+            ? "\n\n⚠️ WARNING: Battery is low. Updating with low battery increases the risk of device failure."
+            : ""
+
+        Alert.alert(
+            'Update Himax Firmware',
+            `This will flash the firmware image from the SD card (output.img in /MANIFEST/).\n\nEnsure the correct firmware file is on the SD card before proceeding.\n\nThe process takes 20-30 seconds.${batteryWarning}`,
+            [
+                { text: 'Cancel', style: 'cancel' },
+                {
+                    text: 'Update',
+                    onPress: async () => {
+                        try {
+                            setIsHimaxUpdating(true)
+                            setHimaxUpdateProgress('Sending firmware flash command...')
+
+                            const response = await updateHimaxFirmware(bleDevice)
+
+                            if (response && /FAILED/i.test(response)) {
+                                const errorMatch = response.match(/error\s+(-?\d+)/i)
+                                const errorCode = errorMatch ? errorMatch[1] : 'unknown'
+                                throw new Error(`Firmware update failed on device (error ${errorCode}). Existing firmware unchanged.`)
+                            }
+
+                            if (response && /OK/i.test(response)) {
+                                setHimaxUpdateProgress('Firmware flashed! Sending reset...')
+
+                                try {
+                                    await runReset(bleDevice)
+                                    await new Promise(r => setTimeout(r, 500))
+                                    await runDisconnect(bleDevice)
+                                } catch (resetErr) {
+                                    logWarn('[Deployment] Reset/disconnect after Himax update:', resetErr)
+                                }
+
+                                setHimaxUpdateProgress('Rebooting device...')
+                                isReconnectingAfterDfu.current = true
+                                await new Promise(r => setTimeout(r, 8000))
+
+                                setHimaxUpdateProgress('Reconnecting...')
+                                try {
+                                    const foundId = await scanForOriginalDevice(bleDeviceId!, 20000)
+                                    if (foundId && bleDevice) {
+                                        setHimaxUpdateProgress('Connecting...')
+                                        await connectDevice(bleDevice, 20000)
+                                        await new Promise(r => setTimeout(r, 2000))
+                                        setHimaxUpdateProgress('Verifying new version...')
+                                        await handleHimaxFirmwareCheck()
+                                        Alert.alert('Success', 'Himax firmware updated successfully!')
+                                    } else {
+                                        throw new Error('Device not found after reboot')
+                                    }
+                                } catch (reconnectErr) {
+                                    Alert.alert(
+                                        'Reconnect Failed',
+                                        'Firmware was flashed but failed to reconnect. Please reconnect manually.',
+                                        [{
+                                            text: 'OK',
+                                            onPress: () => {
+                                                isNavigatingAway.current = true
+                                                navigation.navigate('DeviceDiscovery')
+                                            }
+                                        }]
+                                    )
+                                }
+                            } else {
+                                throw new Error('Unexpected response from device: ' + (response || '(no response)'))
+                            }
+                        } catch (error) {
+                            logError('[Deployment] Himax firmware update failed:', error)
+                            Alert.alert('Update Failed', error instanceof Error ? error.message : 'Unknown error')
+                        } finally {
+                            isReconnectingAfterDfu.current = false
+                            setIsHimaxUpdating(false)
+                            setHimaxUpdateProgress('')
+                        }
+                    }
+                }
+            ]
+        )
+    }, [bleDevice, bleDeviceId, batteryLevel, updateHimaxFirmware, runReset, runDisconnect, connectDevice, navigation, handleHimaxFirmwareCheck])
+
     return {
         formState, submitting, project, availableProjects, captureMethodName, sensitivityLabel,
         device, bleDevice, isInitializing, initProgress, initStep, initErrors,
@@ -844,6 +961,9 @@ export const useStartDeployment = ({
         batteryLevel, sdCardStatus, latestBleFirmware, deviceFirmwareVersion,
         bleFirmwareUpdateAvailable, firmwareUpdateProgress, isUpdatingFirmware,
         isCheckingFirmware, isVerifyingUpdate, firmwareUpdateStatus,
-        handleBatteryCheck, handleSdCardCheck, handleFirmwareCheck, handleBleFirmwareUpdate
+        handleBatteryCheck, handleSdCardCheck, handleFirmwareCheck, handleBleFirmwareUpdate,
+        // Himax Firmware Exports
+        himaxFirmwareVersion, isHimaxUpdating, himaxUpdateProgress, isCheckingHimaxVersion,
+        handleHimaxFirmwareCheck, handleHimaxFirmwareUpdate
     }
 }


### PR DESCRIPTION
- Add AI_FIRMWARE and UPDATE_HIMAX_FIRMWARE BLE command definitions
- Add readRegex for ai_ver to parse Himax version string
- Add firmware command with 120s timeout for long flash operation
- Add handleHimaxFirmwareCheck and handleHimaxFirmwareUpdate to deployment hook
- Add Himax AI Firmware card to AdvancedSettingsSection with:
  - Version check button
  - Flash from SD card button with confirmation dialog
  - Progress/status display during update
  - Error display on failure
  - Auto-reconnect and version verification after reset
- Wire all props through StartMonitoringScreen