### PR TITLE
feat(models): enforce validated status for project ai models

### DIFF
--- a/src/redux/api/__tests__/aiModelsApi.test.tsx
+++ b/src/redux/api/__tests__/aiModelsApi.test.tsx
@@ -106,9 +106,11 @@ describe("aiModelsApi", () => {
 					select: jest.fn().mockReturnValue({
 						eq: jest.fn().mockReturnValue({
 							is: jest.fn().mockReturnValue({
-								order: jest.fn().mockResolvedValue({
-									data: mockModels,
-									error: null,
+								eq: jest.fn().mockReturnValue({
+									order: jest.fn().mockResolvedValue({
+										data: mockModels,
+										error: null,
+									}),
 								}),
 							}),
 						}),
@@ -142,9 +144,11 @@ describe("aiModelsApi", () => {
 					select: jest.fn().mockReturnValue({
 						eq: jest.fn().mockReturnValue({
 							is: jest.fn().mockReturnValue({
-								order: jest.fn().mockResolvedValue({
-									data: null,
-									error: mockError,
+								eq: jest.fn().mockReturnValue({
+									order: jest.fn().mockResolvedValue({
+										data: null,
+										error: mockError,
+									}),
 								}),
 							}),
 						}),
@@ -281,9 +285,11 @@ describe("aiModelsApi", () => {
 					select: jest.fn().mockReturnValue({
 						eq: jest.fn().mockReturnValue({
 							is: jest.fn().mockReturnValue({
-								order: jest.fn().mockResolvedValue({
-									data: [],
-									error: null,
+								eq: jest.fn().mockReturnValue({
+									order: jest.fn().mockResolvedValue({
+										data: [],
+										error: null,
+									}),
 								}),
 							}),
 						}),

--- a/src/redux/api/aiModelsApi.ts
+++ b/src/redux/api/aiModelsApi.ts
@@ -52,6 +52,7 @@ export const aiModelsApi = createApi({
 						.select("*")
 						.eq("organisation_id", organisationId)
 						.is("deleted_at", null) // Exclude soft-deleted models
+						.eq("status", "validated") // Only include fully validated models
 						.order("name", { ascending: true })
 
 					if (error) {

--- a/src/services/ReferenceDataService.ts
+++ b/src/services/ReferenceDataService.ts
@@ -265,6 +265,7 @@ class ReferenceDataService {
             .from('ai_models')
             .select('*')
             .is('deleted_at', null)
+            .eq('status', 'validated')
             .order('name')
 
         if (error) {


### PR DESCRIPTION
- Modified aiModelsApi RTK query to filter by status='validated'.
- Modified ReferenceDataService sync query to filter by status='validated'.
- Updated aiModelsApi unit tests mock chains to support the new eq filter.
- Prevents draft or invalid models from being selected or synced for projects.