### PR TITLE
fix(projects): prevent refetch error on unstarted RTK queries

### DIFF
--- a/src/screens/Projects/ProjectsListScreen.tsx
+++ b/src/screens/Projects/ProjectsListScreen.tsx
@@ -50,16 +50,18 @@ export const Projects = () => {
 
 	// Refetch when global sync finishes
 	useEffect(() => {
-		if (!isGlobalSyncing) {
+		if (!isGlobalSyncing && userId && organisationId) {
 			forceRefetch()
 		}
-	}, [isGlobalSyncing, forceRefetch])
+	}, [isGlobalSyncing, forceRefetch, userId, organisationId])
 
 	// Refresh on focus
 	useFocusEffect(
 		useCallback(() => {
-			forceRefetch()
-		}, [forceRefetch])
+			if (userId && organisationId) {
+				forceRefetch()
+			}
+		}, [forceRefetch, userId, organisationId])
 	)
 
 	const handleRefresh = useCallback(async () => {


### PR DESCRIPTION
- Prevented useGetProjectsQuery from being refetched before user/org is available
- Fixes RTK Query 'Cannot refetch a query that has not been started yet' crash