### PR TITLE
feat(auth): redirect password reset to website with Universal Links f…

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -70,8 +70,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
                 autoVerify: true,
                 data: [
                     {
-                        scheme: "https",
+                        scheme: IS_DEV ? "http" : "https",
                         host: IS_DEV ? "localhost" : "wildlifewatcher.ai",
+                        ...(IS_DEV && { port: "5173" }),
                         pathPrefix: "/reset-password"
                     }
                 ],

--- a/app.config.ts
+++ b/app.config.ts
@@ -38,7 +38,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
             NSPhotoLibraryUsageDescription: "We need access to your photo library to select deployment photos.",
             NSPhotoLibraryAddUsageDescription: "We need access to save deployment photos to your library.",
             ITSAppUsesNonExemptEncryption: false
-        }
+        },
+        associatedDomains: [
+            'applinks:wildlifewatcher.ai'
+        ]
     },
     android: {
         package: BUNDLE_ID,
@@ -61,6 +64,20 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
             "BLUETOOTH_SCAN"
         ],
         softwareKeyboardLayoutMode: "pan",
+        intentFilters: [
+            {
+                action: "VIEW",
+                autoVerify: true,
+                data: [
+                    {
+                        scheme: "https",
+                        host: "wildlifewatcher.ai",
+                        pathPrefix: "/reset-password"
+                    }
+                ],
+                category: ["BROWSABLE", "DEFAULT"]
+            }
+        ],
     },
     web: {
         favicon: "./assets/favicon.png"

--- a/app.config.ts
+++ b/app.config.ts
@@ -39,7 +39,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
             NSPhotoLibraryAddUsageDescription: "We need access to save deployment photos to your library.",
             ITSAppUsesNonExemptEncryption: false
         },
-        associatedDomains: [
+        associatedDomains: IS_DEV ? [] : [
             'applinks:wildlifewatcher.ai'
         ]
     },
@@ -71,7 +71,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
                 data: [
                     {
                         scheme: "https",
-                        host: "wildlifewatcher.ai",
+                        host: IS_DEV ? "localhost" : "wildlifewatcher.ai",
                         pathPrefix: "/reset-password"
                     }
                 ],

--- a/src/config/environments.ts
+++ b/src/config/environments.ts
@@ -15,10 +15,20 @@ export type SupabaseEnvironment = "local" | "cloud-dev" | "cloud-staging" | "clo
 export interface EnvironmentConfig {
 	supabaseUrl: string
 	supabaseAnonKey: string
+	websiteUrl: string
 	displayName: string
 	description: string
 	isProduction: boolean
 }
+
+/**
+ * Website URL per environment, used for:
+ * - Password reset email redirects (resetPasswordForEmail redirectTo)
+ * - Universal Links / App Links prefix in React Navigation
+ */
+export const WEBSITE_URL = __DEV__
+	? "http://localhost:5173"
+	: "https://wildlifewatcher.ai"
 
 /**
  * Environment-specific Supabase configurations
@@ -35,6 +45,7 @@ export const ENVIRONMENT_CONFIGS: Record<
 	local: {
 		supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL || "http://192.168.1.239:54321",
 		supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || "YOUR_LOCAL_ANON_KEY",
+		websiteUrl: "http://localhost:5173",
 		displayName: "Local Development",
 		description: "WSL Supabase (LAN: 192.168.1.239:54321)",
 		isProduction: false,
@@ -42,6 +53,7 @@ export const ENVIRONMENT_CONFIGS: Record<
 	"cloud-dev": {
 		supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL || Constants.expoConfig?.extra?.supabaseUrl || "",
 		supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || Constants.expoConfig?.extra?.supabaseAnonKey || "",
+		websiteUrl: "https://wildlifewatcher.ai",
 		displayName: "Cloud Development",
 		description: "Dev Supabase instance (active development, may break)",
 		isProduction: false,
@@ -49,6 +61,7 @@ export const ENVIRONMENT_CONFIGS: Record<
 	"cloud-staging": {
 		supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL || Constants.expoConfig?.extra?.supabaseUrl || "",
 		supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || Constants.expoConfig?.extra?.supabaseAnonKey || "",
+		websiteUrl: "https://wildlifewatcher.ai",
 		displayName: "Cloud Staging",
 		description: "Staging Supabase instance (pre-production validation)",
 		isProduction: false,
@@ -56,6 +69,7 @@ export const ENVIRONMENT_CONFIGS: Record<
 	"cloud-prod": {
 		supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL || Constants.expoConfig?.extra?.supabaseUrl || "",
 		supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || Constants.expoConfig?.extra?.supabaseAnonKey || "",
+		websiteUrl: "https://wildlifewatcher.ai",
 		displayName: "Cloud Production",
 		description:
 			"Production Supabase instance (requires production credentials)",

--- a/src/config/environments.ts
+++ b/src/config/environments.ts
@@ -15,7 +15,6 @@ export type SupabaseEnvironment = "local" | "cloud-dev" | "cloud-staging" | "clo
 export interface EnvironmentConfig {
 	supabaseUrl: string
 	supabaseAnonKey: string
-	websiteUrl: string
 	displayName: string
 	description: string
 	isProduction: boolean
@@ -45,7 +44,6 @@ export const ENVIRONMENT_CONFIGS: Record<
 	local: {
 		supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL || "http://192.168.1.239:54321",
 		supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || "YOUR_LOCAL_ANON_KEY",
-		websiteUrl: "http://localhost:5173",
 		displayName: "Local Development",
 		description: "WSL Supabase (LAN: 192.168.1.239:54321)",
 		isProduction: false,
@@ -53,7 +51,6 @@ export const ENVIRONMENT_CONFIGS: Record<
 	"cloud-dev": {
 		supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL || Constants.expoConfig?.extra?.supabaseUrl || "",
 		supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || Constants.expoConfig?.extra?.supabaseAnonKey || "",
-		websiteUrl: "https://wildlifewatcher.ai",
 		displayName: "Cloud Development",
 		description: "Dev Supabase instance (active development, may break)",
 		isProduction: false,
@@ -61,7 +58,6 @@ export const ENVIRONMENT_CONFIGS: Record<
 	"cloud-staging": {
 		supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL || Constants.expoConfig?.extra?.supabaseUrl || "",
 		supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || Constants.expoConfig?.extra?.supabaseAnonKey || "",
-		websiteUrl: "https://wildlifewatcher.ai",
 		displayName: "Cloud Staging",
 		description: "Staging Supabase instance (pre-production validation)",
 		isProduction: false,
@@ -69,7 +65,6 @@ export const ENVIRONMENT_CONFIGS: Record<
 	"cloud-prod": {
 		supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL || Constants.expoConfig?.extra?.supabaseUrl || "",
 		supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || Constants.expoConfig?.extra?.supabaseAnonKey || "",
-		websiteUrl: "https://wildlifewatcher.ai",
 		displayName: "Cloud Production",
 		description:
 			"Production Supabase instance (requires production credentials)",

--- a/src/hooks/__tests__/useSupabaseClient.test.tsx
+++ b/src/hooks/__tests__/useSupabaseClient.test.tsx
@@ -80,6 +80,7 @@ describe("useSupabaseClient", () => {
 		mockGetEnvironmentConfig.mockResolvedValue({
 			supabaseUrl: "https://test.supabase.co",
 			supabaseAnonKey: "test-key",
+			websiteUrl: "https://wildlifewatcher.ai",
 			displayName: "Test",
 			description: "Test environment",
 			isProduction: false,

--- a/src/hooks/__tests__/useSupabaseClient.test.tsx
+++ b/src/hooks/__tests__/useSupabaseClient.test.tsx
@@ -80,7 +80,6 @@ describe("useSupabaseClient", () => {
 		mockGetEnvironmentConfig.mockResolvedValue({
 			supabaseUrl: "https://test.supabase.co",
 			supabaseAnonKey: "test-key",
-			websiteUrl: "https://wildlifewatcher.ai",
 			displayName: "Test",
 			description: "Test environment",
 			isProduction: false,

--- a/src/navigation/linking.ts
+++ b/src/navigation/linking.ts
@@ -13,14 +13,14 @@ export const linking: LinkingOptions<any> = {
 		prefix,
 		"wildlifewatcher://",
 		"com.wildlife.wildlifewatcher://",
-		"https://wildlifewatcher.ai",
+		"https://wildlifewatcher.ai/",
 		"exp://localhost:8081/",
 		"exp://192.168.1.8:8081/", // Your local IP
 	],
 	config: {
 		screens: {
 			Login: "auth/callback",
-			ForgotPassword: "auth/reset-password",
+			ForgotPassword: "reset-password",
 			Register: "auth/confirm",
 			Home: "",
 			// Add other screens as needed
@@ -34,7 +34,7 @@ export const linking: LinkingOptions<any> = {
 		// Let useDeepLinking hook handle auth routes to avoid conflicts
 		if (
 			path &&
-			(path.includes("auth/reset-password") ||
+			(path.includes("reset-password") ||
 				path.includes("auth/callback") ||
 				path.includes("auth/confirm"))
 		) {

--- a/src/navigation/linking.ts
+++ b/src/navigation/linking.ts
@@ -13,6 +13,7 @@ export const linking: LinkingOptions<any> = {
 		prefix,
 		"wildlifewatcher://",
 		"com.wildlife.wildlifewatcher://",
+		"https://wildlifewatcher.ai",
 		"exp://localhost:8081/",
 		"exp://192.168.1.8:8081/", // Your local IP
 	],

--- a/src/navigation/linking.ts
+++ b/src/navigation/linking.ts
@@ -2,6 +2,7 @@ import { LinkingOptions } from "@react-navigation/native"
 import * as Linking from "expo-linking"
 import { getStateFromPath } from "@react-navigation/native"
 import { log } from '../utils/logger'
+import { WEBSITE_URL } from '../config/environments'
 
 
 const prefix = Linking.createURL("/")
@@ -13,7 +14,7 @@ export const linking: LinkingOptions<any> = {
 		prefix,
 		"wildlifewatcher://",
 		"com.wildlife.wildlifewatcher://",
-		"https://wildlifewatcher.ai/",
+		`${WEBSITE_URL}/`,
 		"exp://localhost:8081/",
 		"exp://192.168.1.8:8081/", // Your local IP
 	],

--- a/src/services/__tests__/supabase-environment-switching.test.ts
+++ b/src/services/__tests__/supabase-environment-switching.test.ts
@@ -94,6 +94,7 @@ describe("Supabase Client Environment Switching", () => {
 		mockGetEnvironmentConfig.mockResolvedValue({
 			supabaseUrl: "https://test.supabase.co",
 			supabaseAnonKey: "test-anon-key",
+			websiteUrl: "https://wildlifewatcher.ai",
 			displayName: "Test Environment",
 			description: "Test description",
 			isProduction: false,
@@ -210,6 +211,7 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "https://new.supabase.co",
 				supabaseAnonKey: "new-anon-key",
+				websiteUrl: "https://wildlifewatcher.ai",
 				displayName: "New Environment",
 				description: "New description",
 				isProduction: false,
@@ -334,6 +336,7 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "https://test.supabase.co",
 				supabaseAnonKey: "test-key",
+				websiteUrl: "https://wildlifewatcher.ai",
 				displayName: "Test Env",
 				description: "Test",
 				isProduction: false,
@@ -345,6 +348,7 @@ describe("Supabase Client Environment Switching", () => {
 			expect(env).toEqual({
 				supabaseUrl: "https://test.supabase.co",
 				supabaseAnonKey: "test-key",
+				websiteUrl: "https://wildlifewatcher.ai",
 				displayName: "Test Env",
 				description: "Test",
 				isProduction: false,
@@ -362,6 +366,7 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "https://new.supabase.co",
 				supabaseAnonKey: "new-key",
+				websiteUrl: "https://wildlifewatcher.ai",
 				displayName: "New Env",
 				description: "New",
 				isProduction: true,
@@ -381,6 +386,7 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "http://localhost:54321",
 				supabaseAnonKey: "local-key",
+				websiteUrl: "http://localhost:5173",
 				displayName: "Local",
 				description: "Local Supabase",
 				isProduction: false,
@@ -393,6 +399,7 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "https://cloud.supabase.co",
 				supabaseAnonKey: "cloud-key",
+				websiteUrl: "https://wildlifewatcher.ai",
 				displayName: "Cloud Dev",
 				description: "Cloud Development",
 				isProduction: false,
@@ -431,6 +438,7 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "",
 				supabaseAnonKey: "",
+				websiteUrl: "https://wildlifewatcher.ai",
 				displayName: "Invalid",
 				description: "Invalid config",
 				isProduction: false,

--- a/src/services/__tests__/supabase-environment-switching.test.ts
+++ b/src/services/__tests__/supabase-environment-switching.test.ts
@@ -94,7 +94,6 @@ describe("Supabase Client Environment Switching", () => {
 		mockGetEnvironmentConfig.mockResolvedValue({
 			supabaseUrl: "https://test.supabase.co",
 			supabaseAnonKey: "test-anon-key",
-			websiteUrl: "https://wildlifewatcher.ai",
 			displayName: "Test Environment",
 			description: "Test description",
 			isProduction: false,
@@ -211,7 +210,6 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "https://new.supabase.co",
 				supabaseAnonKey: "new-anon-key",
-				websiteUrl: "https://wildlifewatcher.ai",
 				displayName: "New Environment",
 				description: "New description",
 				isProduction: false,
@@ -336,8 +334,7 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "https://test.supabase.co",
 				supabaseAnonKey: "test-key",
-				websiteUrl: "https://wildlifewatcher.ai",
-				displayName: "Test Env",
+					displayName: "Test Env",
 				description: "Test",
 				isProduction: false,
 			})
@@ -348,8 +345,7 @@ describe("Supabase Client Environment Switching", () => {
 			expect(env).toEqual({
 				supabaseUrl: "https://test.supabase.co",
 				supabaseAnonKey: "test-key",
-				websiteUrl: "https://wildlifewatcher.ai",
-				displayName: "Test Env",
+					displayName: "Test Env",
 				description: "Test",
 				isProduction: false,
 			})
@@ -366,7 +362,6 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "https://new.supabase.co",
 				supabaseAnonKey: "new-key",
-				websiteUrl: "https://wildlifewatcher.ai",
 				displayName: "New Env",
 				description: "New",
 				isProduction: true,
@@ -386,7 +381,6 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "http://localhost:54321",
 				supabaseAnonKey: "local-key",
-				websiteUrl: "http://localhost:5173",
 				displayName: "Local",
 				description: "Local Supabase",
 				isProduction: false,
@@ -399,7 +393,6 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "https://cloud.supabase.co",
 				supabaseAnonKey: "cloud-key",
-				websiteUrl: "https://wildlifewatcher.ai",
 				displayName: "Cloud Dev",
 				description: "Cloud Development",
 				isProduction: false,
@@ -438,7 +431,6 @@ describe("Supabase Client Environment Switching", () => {
 			mockGetEnvironmentConfig.mockResolvedValueOnce({
 				supabaseUrl: "",
 				supabaseAnonKey: "",
-				websiteUrl: "https://wildlifewatcher.ai",
 				displayName: "Invalid",
 				description: "Invalid config",
 				isProduction: false,

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -13,6 +13,7 @@ import {
 } from "../redux/api/auth/types"
 
 import { log, logError, logWarn } from '../utils/logger'
+import { WEBSITE_URL } from "../config/environments"
 
 
 /**
@@ -482,7 +483,7 @@ export const setupAuthListener = (
 export const resetPassword = async (email: string): Promise<void> => {
 	try {
 		const { error } = await supabase().auth.resetPasswordForEmail(email, {
-			redirectTo: "https://wildlifewatcher.ai/reset-password",
+			redirectTo: `${WEBSITE_URL}/reset-password`,
 		})
 
 		if (error) {

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -482,7 +482,7 @@ export const setupAuthListener = (
 export const resetPassword = async (email: string): Promise<void> => {
 	try {
 		const { error } = await supabase().auth.resetPasswordForEmail(email, {
-			redirectTo: "wildlifewatcher://auth/reset-password",
+			redirectTo: "https://wildlifewatcher.ai/reset-password",
 		})
 
 		if (error) {

--- a/tests/integration/services/auth.test.ts
+++ b/tests/integration/services/auth.test.ts
@@ -389,7 +389,7 @@ describe("Authentication Service", () => {
 			expect(
 				mockSupabaseClient.auth.resetPasswordForEmail,
 			).toHaveBeenCalledWith("test@example.com", {
-				redirectTo: "https://wildlifewatcher.ai/reset-password",
+				redirectTo: "http://localhost:5173/reset-password",
 			})
 		})
 

--- a/tests/integration/services/auth.test.ts
+++ b/tests/integration/services/auth.test.ts
@@ -389,7 +389,7 @@ describe("Authentication Service", () => {
 			expect(
 				mockSupabaseClient.auth.resetPasswordForEmail,
 			).toHaveBeenCalledWith("test@example.com", {
-				redirectTo: "wildlifewatcher://auth/reset-password",
+				redirectTo: "https://wildlifewatcher.ai/reset-password",
 			})
 		})
 


### PR DESCRIPTION
…allback

Change resetPasswordForEmail redirectTo from wildlifewatcher:// custom scheme to https://wildlifewatcher.ai/reset-password so the reset flow works for users without the mobile app installed.

- Add iOS associatedDomains (applinks:wildlifewatcher.ai) to app.config.ts

- Add Android intentFilters for https://wildlifewatcher.ai/reset-password

- Add https://wildlifewatcher.ai to React Navigation linking prefixes

- Update auth.test.ts assertion for new redirect URL