### PR TITLE
feat: phone photos of camera deployments in the field

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -117,6 +117,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         ],
         "expo-localization",
         [
+            "expo-image-picker",
+            {
+                "cameraPermission": "We need access to your camera to take photos of the deployment site.",
+                "photosPermission": "We need access to your photo library to select deployment photos."
+            }
+        ],
+        [
             "expo-location",
             {
                 "isAndroidBackgroundLocationEnabled": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "expo-dev-client": "~6.0.20",
         "expo-file-system": "~19.0.21",
         "expo-image": "~3.0.11",
+        "expo-image-picker": "~17.0.11",
         "expo-linking": "~8.0.11",
         "expo-localization": "~17.0.8",
         "expo-location": "~19.0.8",
@@ -11110,6 +11111,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.11.tgz",
+      "integrity": "sha512-/apkoyukDvsCHHb9fzP+F34A1uQqSzUtYH/2P/xJACNEwq+mwEXjXvVU8bzlJq6ih0Qo1+tpVivIa7B9kYSwOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-json-utils": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "expo-dev-client": "~6.0.20",
     "expo-file-system": "~19.0.21",
     "expo-image": "~3.0.11",
+    "expo-image-picker": "~17.0.11",
     "expo-linking": "~8.0.11",
     "expo-localization": "~17.0.8",
     "expo-location": "~19.0.8",

--- a/src/components/ui/DeploymentPhotoStrip.tsx
+++ b/src/components/ui/DeploymentPhotoStrip.tsx
@@ -17,31 +17,46 @@ interface Props {
  */
 export const DeploymentPhotoStrip = ({ deployment, size = 72 }: Props) => {
     const [photos, setPhotos] = useState<{ url: string; cacheKey: string }[]>([])
+    const [prevPathsKey, setPrevPathsKey] = useState('')
 
+    // @json fields return a fresh array on every access, so depend on a
+    // stable string form to avoid re-signing URLs on every render.
     const rawPaths = deployment?.cameraLocationImagePaths
+    const pathsKey = typeof rawPaths === 'string' ? rawPaths : JSON.stringify(rawPaths || [])
+
+    // Clear stale thumbnails synchronously during render when paths change,
+    // so the UI never briefly shows the previous deployment's photos.
+    if (pathsKey !== prevPathsKey) {
+        setPrevPathsKey(pathsKey)
+        const nextPaths: string[] = JSON.parse(pathsKey)
+        if (nextPaths.length === 0) setPhotos([])
+    }
+
     useEffect(() => {
+        const paths: string[] = JSON.parse(pathsKey)
+        if (paths.length === 0) return
+
         let cancelled = false
-        if (!deployment) {
-            setPhotos([])
-            return
-        }
-        const paths: string[] = typeof rawPaths === 'string' ? JSON.parse(rawPaths) : (rawPaths || [])
-        Promise.all(
-            paths.map(async (path) => {
-                const url = await DeploymentPhotoService.getDisplayUrl(path)
-                return url ? { url, cacheKey: path } : null
-            })
-        )
-            .then((resolved) => {
-                if (!cancelled) setPhotos(resolved.filter((p): p is { url: string; cacheKey: string } => !!p))
-            })
-            .catch(() => {
-                if (!cancelled) setPhotos([])
-            })
+        ;(async () => {
+            let nextPhotos: { url: string; cacheKey: string }[] = []
+            try {
+                const resolved = await Promise.all(
+                    paths.map(async (path) => {
+                        const url = await DeploymentPhotoService.getDisplayUrl(path)
+                        return url ? { url, cacheKey: path } : null
+                    })
+                )
+                nextPhotos = resolved.filter((p): p is { url: string; cacheKey: string } => !!p)
+            } catch {
+                // nextPhotos stays [] — failed resolution is not fatal
+            }
+            if (!cancelled) setPhotos(nextPhotos)
+        })()
+
         return () => {
             cancelled = true
         }
-    }, [deployment, rawPaths])
+    }, [pathsKey])
 
     if (photos.length === 0) return null
 

--- a/src/components/ui/DeploymentPhotoStrip.tsx
+++ b/src/components/ui/DeploymentPhotoStrip.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react'
+import { ScrollView, StyleSheet, View } from 'react-native'
+import { Image } from 'expo-image'
+import type Deployment from '../../database/models/Deployment'
+import { DeploymentPhotoService } from '../../services/DeploymentPhotoService'
+
+interface Props {
+    deployment: Deployment | undefined | null
+    size?: number
+}
+
+/**
+ * Horizontal strip of the phone photos taken at a deployment site.
+ * Resolves local paths or signed storage URLs; disk-cached by storage path
+ * so photos viewed once stay visible offline. Renders nothing if the
+ * deployment has no photos (or none can be resolved yet).
+ */
+export const DeploymentPhotoStrip = ({ deployment, size = 72 }: Props) => {
+    const [photos, setPhotos] = useState<{ url: string; cacheKey: string }[]>([])
+
+    const rawPaths = deployment?.cameraLocationImagePaths
+    useEffect(() => {
+        let cancelled = false
+        if (!deployment) {
+            setPhotos([])
+            return
+        }
+        const paths: string[] = typeof rawPaths === 'string' ? JSON.parse(rawPaths) : (rawPaths || [])
+        Promise.all(
+            paths.map(async (path) => {
+                const url = await DeploymentPhotoService.getDisplayUrl(path)
+                return url ? { url, cacheKey: path } : null
+            })
+        )
+            .then((resolved) => {
+                if (!cancelled) setPhotos(resolved.filter((p): p is { url: string; cacheKey: string } => !!p))
+            })
+            .catch(() => {
+                if (!cancelled) setPhotos([])
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [deployment, rawPaths])
+
+    if (photos.length === 0) return null
+
+    return (
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.strip}>
+            <View style={styles.row}>
+                {photos.map((photo) => (
+                    <Image
+                        key={photo.cacheKey}
+                        source={{ uri: photo.url, cacheKey: photo.cacheKey }}
+                        style={[styles.photo, { width: size, height: size }]}
+                        contentFit="cover"
+                        cachePolicy="disk"
+                        transition={150}
+                    />
+                ))}
+            </View>
+        </ScrollView>
+    )
+}
+
+const styles = StyleSheet.create({
+    strip: {
+        marginBottom: 12,
+    },
+    row: {
+        flexDirection: 'row',
+        gap: 8,
+    },
+    photo: {
+        borderRadius: 8,
+        backgroundColor: 'rgba(0,0,0,0.05)',
+    },
+})

--- a/src/features/maps/components/DeploymentCard.tsx
+++ b/src/features/maps/components/DeploymentCard.tsx
@@ -4,6 +4,7 @@ import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-na
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons'
 import { useExtendedTheme } from '../../../theme'
 import type Deployment from '../../../database/models/Deployment'
+import { DeploymentPhotoStrip } from '../../../components/ui/DeploymentPhotoStrip'
 
 interface Props {
     deployment: Deployment | undefined | null
@@ -90,6 +91,8 @@ const DeploymentCardComponent: React.FC<Props> = ({ deployment, device, isVisibl
                         </Text>
                     </View>
                 )}
+
+                <DeploymentPhotoStrip deployment={deployment} />
 
                 <TouchableOpacity
                     style={[styles.button, { backgroundColor: colors.primary }]}

--- a/src/screens/Deployments/StartMonitoringScreen.tsx
+++ b/src/screens/Deployments/StartMonitoringScreen.tsx
@@ -15,6 +15,7 @@ import { useGetAiModelsQuery } from '../../redux/api/projectsApi'
 import { LoRaWANSection } from './components/LoRaWANSection'
 
 import { MetadataSection } from './components/MetadataSection'
+import { DeploymentPhotosSection } from './components/DeploymentPhotosSection'
 import { HelpDialog } from '../../components/ui/HelpDialog'
 import { FinishProgressDialog } from '../Devices/components/FinishProgressDialog'
 import { AdvancedSettingsSection } from './components/AdvancedSettingsSection'
@@ -43,6 +44,7 @@ export const StartMonitoringDetailsStep = () => {
         device, bleDevice, isInitializing, initProgress, initStep, initErrors, setInitErrors, aiProcessorFailed,
         finishProgress, finishStep, finishLogs, isFinishing, isStartSuccess,
         handleImageCaptured,
+        deploymentPhotoPaths, handleAddDeploymentPhoto, handleRemoveDeploymentPhoto,
         handleNotesChange, handleProjectChange,
         handleCameraHeightChange, handleStartDeployment, handleFinishDismiss,
         helpVisible, helpTitle, helpContent, showHelp, handleDismissHelp,
@@ -330,6 +332,14 @@ export const StartMonitoringDetailsStep = () => {
                     notes={formState.notes}
                     onNotesChange={handleNotesChange}
                     onShowHelp={showHelp}
+                />
+
+                <DeploymentPhotosSection
+                    photoPaths={deploymentPhotoPaths}
+                    onAddPhoto={handleAddDeploymentPhoto}
+                    onRemovePhoto={handleRemoveDeploymentPhoto}
+                    onShowHelp={showHelp}
+                    disabled={submitting || isInitializing}
                 />
 
                 <AdvancedSettingsSection

--- a/src/screens/Deployments/components/DeploymentPhotosSection.tsx
+++ b/src/screens/Deployments/components/DeploymentPhotosSection.tsx
@@ -13,6 +13,8 @@ interface Props {
     disabled?: boolean
 }
 
+const MAX_PHOTOS = 5
+
 const PICKER_OPTIONS: ImagePicker.ImagePickerOptions = {
     mediaTypes: ['images'],
     quality: 0.7,
@@ -28,9 +30,13 @@ export const DeploymentPhotosSection = ({
 }: Props) => {
     const [busy, setBusy] = useState(false)
 
+    const remainingSlots = MAX_PHOTOS - photoPaths.length
+    const atLimit = remainingSlots <= 0
+
     const handleResult = async (result: ImagePicker.ImagePickerResult) => {
         if (result.canceled || !result.assets?.length) return
-        for (const asset of result.assets) {
+        // Cap here too: Android pickers don't always honor selectionLimit
+        for (const asset of result.assets.slice(0, remainingSlots)) {
             const persisted = await DeploymentPhotoService.persistLocalPhoto(asset.uri)
             onAddPhoto(persisted)
         }
@@ -59,7 +65,7 @@ export const DeploymentPhotosSection = ({
             const result = await ImagePicker.launchImageLibraryAsync({
                 ...PICKER_OPTIONS,
                 allowsMultipleSelection: true,
-                selectionLimit: 5,
+                selectionLimit: remainingSlots,
             })
             await handleResult(result)
         } catch (e) {
@@ -114,7 +120,7 @@ export const DeploymentPhotosSection = ({
                         mode="outlined"
                         icon="camera"
                         onPress={takePhoto}
-                        disabled={disabled || busy}
+                        disabled={disabled || busy || atLimit}
                         style={styles.button}
                     >
                         <Text>Take Photo</Text>
@@ -123,7 +129,7 @@ export const DeploymentPhotosSection = ({
                         mode="outlined"
                         icon="image-multiple"
                         onPress={pickFromLibrary}
-                        disabled={disabled || busy}
+                        disabled={disabled || busy || atLimit}
                         style={styles.button}
                     >
                         <Text>From Library</Text>

--- a/src/screens/Deployments/components/DeploymentPhotosSection.tsx
+++ b/src/screens/Deployments/components/DeploymentPhotosSection.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react'
+import { Alert, Image, ScrollView, StyleSheet, View } from 'react-native'
+import { Card, Button, Text, IconButton } from 'react-native-paper'
+import * as ImagePicker from 'expo-image-picker'
+import { DeploymentPhotoService } from '../../../services/DeploymentPhotoService'
+import { logWarn } from '../../../utils/logger'
+
+interface Props {
+    photoPaths: string[]
+    onAddPhoto: (path: string) => void
+    onRemovePhoto: (path: string) => void
+    onShowHelp: (title: string, content: string) => void
+    disabled?: boolean
+}
+
+const PICKER_OPTIONS: ImagePicker.ImagePickerOptions = {
+    mediaTypes: ['images'],
+    quality: 0.7,
+    exif: false,
+}
+
+export const DeploymentPhotosSection = ({
+    photoPaths,
+    onAddPhoto,
+    onRemovePhoto,
+    onShowHelp,
+    disabled
+}: Props) => {
+    const [busy, setBusy] = useState(false)
+
+    const handleResult = async (result: ImagePicker.ImagePickerResult) => {
+        if (result.canceled || !result.assets?.length) return
+        for (const asset of result.assets) {
+            const persisted = await DeploymentPhotoService.persistLocalPhoto(asset.uri)
+            onAddPhoto(persisted)
+        }
+    }
+
+    const takePhoto = async () => {
+        setBusy(true)
+        try {
+            const permission = await ImagePicker.requestCameraPermissionsAsync()
+            if (!permission.granted) {
+                Alert.alert('Camera permission needed', 'Please allow camera access to take deployment photos.')
+                return
+            }
+            const result = await ImagePicker.launchCameraAsync(PICKER_OPTIONS)
+            await handleResult(result)
+        } catch (e) {
+            logWarn('[DeploymentPhotosSection] Failed to take photo:', e)
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    const pickFromLibrary = async () => {
+        setBusy(true)
+        try {
+            const result = await ImagePicker.launchImageLibraryAsync({
+                ...PICKER_OPTIONS,
+                allowsMultipleSelection: true,
+                selectionLimit: 5,
+            })
+            await handleResult(result)
+        } catch (e) {
+            logWarn('[DeploymentPhotosSection] Failed to pick photo:', e)
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    const renderHelp = (props: any) => (
+        <Button
+            {...props}
+            icon="help-circle-outline"
+            onPress={() => onShowHelp(
+                'Deployment Photos',
+                'Take a few photos of the camera in place and its surroundings. They are shared with everyone in the project, making the camera much easier to find again in the field.\n\nGood photos to take:\n• The camera mounted in position\n• The view standing a few steps back\n• A recognisable landmark nearby'
+            )}
+        >
+            <Text>Help</Text>
+        </Button>
+    )
+
+    return (
+        <Card style={styles.card}>
+            <Card.Title title="Deployment Photos" right={renderHelp} />
+            <Card.Content style={styles.content}>
+                <Text variant="bodySmall" style={styles.hint}>
+                    Photos of the camera in the field help anyone in the project find it later.
+                </Text>
+
+                {photoPaths.length > 0 && (
+                    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                        <View style={styles.thumbRow}>
+                            {photoPaths.map((path) => (
+                                <View key={path} style={styles.thumbContainer}>
+                                    <Image source={{ uri: path }} style={styles.thumb} />
+                                    <IconButton
+                                        icon="close-circle"
+                                        size={20}
+                                        style={styles.removeButton}
+                                        onPress={() => onRemovePhoto(path)}
+                                        disabled={disabled || busy}
+                                    />
+                                </View>
+                            ))}
+                        </View>
+                    </ScrollView>
+                )}
+
+                <View style={styles.buttonRow}>
+                    <Button
+                        mode="outlined"
+                        icon="camera"
+                        onPress={takePhoto}
+                        disabled={disabled || busy}
+                        style={styles.button}
+                    >
+                        <Text>Take Photo</Text>
+                    </Button>
+                    <Button
+                        mode="outlined"
+                        icon="image-multiple"
+                        onPress={pickFromLibrary}
+                        disabled={disabled || busy}
+                        style={styles.button}
+                    >
+                        <Text>From Library</Text>
+                    </Button>
+                </View>
+            </Card.Content>
+        </Card>
+    )
+}
+
+const styles = StyleSheet.create({
+    card: {},
+    content: { gap: 12 },
+    hint: { opacity: 0.7 },
+    thumbRow: {
+        flexDirection: 'row',
+        gap: 8,
+    },
+    thumbContainer: {
+        position: 'relative',
+    },
+    thumb: {
+        width: 96,
+        height: 96,
+        borderRadius: 8,
+    },
+    removeButton: {
+        position: 'absolute',
+        top: -12,
+        right: -12,
+        margin: 0,
+    },
+    buttonRow: {
+        flexDirection: 'row',
+        gap: 8,
+    },
+    button: {
+        flex: 1,
+    },
+})

--- a/src/screens/Deployments/hooks/useStartDeployment.ts
+++ b/src/screens/Deployments/hooks/useStartDeployment.ts
@@ -5,6 +5,7 @@ import { Q } from '@nozbe/watermelondb'
 import database from '../../../database'
 import { useFocusEffect } from '@react-navigation/native'
 import { DeploymentService } from '../../../services/DeploymentService'
+import { DeploymentPhotoService } from '../../../services/DeploymentPhotoService'
 import ProjectService from '../../../services/ProjectService'
 import ReferenceDataService from '../../../services/ReferenceDataService'
 import Device from '../../../database/models/Device'
@@ -81,6 +82,9 @@ export const useStartDeployment = ({
         testImagePath: undefined as string | undefined
     })
 
+    // Phone photos of the deployment site (local file:// paths until uploaded)
+    const [deploymentPhotoPaths, setDeploymentPhotoPaths] = useState<string[]>([])
+
     const [submitting, setSubmitting] = useState(false)
     const [project, setProject] = useState<any>(null)
     const [availableProjects, setAvailableProjects] = useState<ProjectWithDetails[]>([])
@@ -129,6 +133,15 @@ export const useStartDeployment = ({
     // Memoized handlers to prevent infinite loops in child components
     const handleImageCaptured = useCallback((path: string) => {
         setFormState(prev => ({ ...prev, testImagePath: path }))
+    }, [])
+
+    const handleAddDeploymentPhoto = useCallback((path: string) => {
+        setDeploymentPhotoPaths(prev => [...prev, path])
+    }, [])
+
+    const handleRemoveDeploymentPhoto = useCallback((path: string) => {
+        setDeploymentPhotoPaths(prev => prev.filter(p => p !== path))
+        DeploymentPhotoService.removeLocalPhoto(path)
     }, [])
 
     const handleNotesChange = useCallback((notes: string) => {
@@ -510,11 +523,17 @@ export const useStartDeployment = ({
                 lorawanRssiAtStart: lorawanRssi,
                 lorawanSnrAtStart: lorawanSnr,
                 startComments: formState.notes,
-                cameraImagePaths: [],
+                cameraImagePaths: deploymentPhotoPaths,
             })
             deploymentIdRef.current = newDeployment.id
             setDeploymentStartTime(newDeployment.deploymentStart || new Date())
             progress.addLog(`Deployment created: ${newDeployment.id.substring(0, 8)}...`)
+
+            // Upload site photos in the background; failures are retried on later syncs
+            if (deploymentPhotoPaths.length > 0) {
+                DeploymentPhotoService.uploadPendingPhotos(newDeployment.id, user.id)
+                    .catch((e) => logWarn('[Deployment] Photo upload deferred:', e))
+            }
 
             // 6. Reset OPs to factory defaults before applying deployment config
             try {
@@ -558,7 +577,7 @@ export const useStartDeployment = ({
             Alert.alert('Error', 'Failed to start deployment: ' + (error as any).message)
             isStartDeploymentInProgress.current = false
         }
-    }, [formState.cameraHeight, formState.notes, bleDevice, bleSession, project, user, deviceId, startConfigure, progress, monitoring, batteryLevel, device?.deviceEui, gpsLocation, locationName, sdCardStatus?.free, sdCardStatus?.total, aiProcessorFailed, initPayload?.deviceFirmwareVersion, initErrors.deviceHealth])  
+    }, [formState.cameraHeight, formState.notes, bleDevice, bleSession, project, user, deviceId, startConfigure, progress, monitoring, batteryLevel, device?.deviceEui, gpsLocation, locationName, sdCardStatus?.free, sdCardStatus?.total, aiProcessorFailed, initPayload?.deviceFirmwareVersion, initErrors.deviceHealth, deploymentPhotoPaths])
 
     const handleFinishDismiss = useCallback(() => {
         progress.setIsFinishing(false)
@@ -650,6 +669,8 @@ export const useStartDeployment = ({
         isStoppingMonitoring: monitoring.isStoppingMonitoring,
         isNavigatingAway, handleImageCaptured, handleNotesChange, handleProjectChange,
         handleCameraHeightChange, handleStartDeployment, handleFinishDismiss,
+        // Deployment site photos
+        deploymentPhotoPaths, handleAddDeploymentPhoto, handleRemoveDeploymentPhoto,
         helpVisible, helpTitle, helpContent, showHelp, handleDismissHelp,
         // Dropdown & Additional Location State
         locationName, setLocationName, availableLocations, isCustomLocation, setIsCustomLocation,

--- a/src/services/DeploymentPhotoService.ts
+++ b/src/services/DeploymentPhotoService.ts
@@ -56,7 +56,8 @@ export const DeploymentPhotoService = {
             await FileSystem.makeDirectoryAsync(PHOTOS_DIR, { intermediates: true })
         }
 
-        const extension = sourceUri.split('.').pop()?.toLowerCase() || 'jpg'
+        const cleanUri = sourceUri.split('?')[0]
+        const extension = (cleanUri.includes('.') && cleanUri.split('.').pop()?.toLowerCase()) || 'jpg'
         const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${extension}`
         const destination = PHOTOS_DIR + filename
 

--- a/src/services/DeploymentPhotoService.ts
+++ b/src/services/DeploymentPhotoService.ts
@@ -1,0 +1,215 @@
+import * as FileSystem from 'expo-file-system/legacy'
+import database from '../database'
+import Deployment from '../database/models/Deployment'
+import OutboxService from './OutboxService'
+import { mapModelToPayload } from './DeploymentService'
+import SupabaseSyncService from './SupabaseSyncService'
+import { getSupabaseClient } from './supabase'
+import { log, logError, logWarn } from '../utils/logger'
+
+const PHOTOS_DIR = FileSystem.documentDirectory + 'deployment-photos/'
+const BUCKET = 'deployment-photos'
+const SIGNED_URL_TTL_SECONDS = 60 * 60 // 1 hour
+
+const isLocalPath = (path: string) => path.startsWith('file://')
+
+/**
+ * Decode base64 to a Uint8Array without external dependencies
+ * (Hermes does not reliably expose atob/Buffer).
+ */
+function base64ToBytes(base64: string): Uint8Array {
+    const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+    const clean = base64.replace(/[=]+$/, '')
+    const bytes = new Uint8Array(Math.floor((clean.length * 3) / 4))
+    let buffer = 0
+    let bits = 0
+    let index = 0
+    for (let i = 0; i < clean.length; i++) {
+        const value = alphabet.indexOf(clean[i])
+        if (value === -1) continue
+        buffer = (buffer << 6) | value
+        bits += 6
+        if (bits >= 8) {
+            bits -= 8
+            bytes[index++] = (buffer >> bits) & 0xff
+        }
+    }
+    return bytes
+}
+
+/**
+ * Handles phone photos of camera deployments:
+ * - persists picked images into app storage so they survive the picker cache
+ * - uploads pending local photos to the deployment-photos bucket
+ *   ({project_id}/{deployment_id}/{filename}) once online
+ * - swaps local paths for storage paths on the deployment record
+ * - resolves display URLs (local file or signed storage URL)
+ */
+export const DeploymentPhotoService = {
+    /**
+     * Copy a freshly picked/captured image out of the picker cache into
+     * app document storage. Returns the persistent local path.
+     */
+    persistLocalPhoto: async (sourceUri: string): Promise<string> => {
+        const dirInfo = await FileSystem.getInfoAsync(PHOTOS_DIR)
+        if (!dirInfo.exists) {
+            await FileSystem.makeDirectoryAsync(PHOTOS_DIR, { intermediates: true })
+        }
+
+        const extension = sourceUri.split('.').pop()?.toLowerCase() || 'jpg'
+        const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${extension}`
+        const destination = PHOTOS_DIR + filename
+
+        await FileSystem.copyAsync({ from: sourceUri, to: destination })
+        log('[DeploymentPhotoService] Persisted photo:', destination)
+        return destination
+    },
+
+    /**
+     * Delete a locally persisted photo (e.g. user removed it before deploying).
+     */
+    removeLocalPhoto: async (path: string): Promise<void> => {
+        if (!isLocalPath(path)) return
+        try {
+            await FileSystem.deleteAsync(path, { idempotent: true })
+        } catch (e) {
+            logWarn('[DeploymentPhotoService] Failed to delete local photo:', e)
+        }
+    },
+
+    /**
+     * Upload all still-local photos of a deployment to Supabase storage and
+     * replace the local paths on the record with storage paths.
+     * Safe to call repeatedly; already-uploaded photos are skipped and
+     * failures leave the local path in place for the next attempt.
+     */
+    uploadPendingPhotos: async (deploymentId: string, userId: string): Promise<void> => {
+        const deploymentsCollection = database.get<Deployment>('deployments')
+        let deployment: Deployment
+        try {
+            deployment = await deploymentsCollection.find(deploymentId)
+        } catch {
+            logWarn('[DeploymentPhotoService] Deployment not found:', deploymentId)
+            return
+        }
+
+        const rawPaths = deployment.cameraLocationImagePaths
+        const paths: string[] = typeof rawPaths === 'string' ? JSON.parse(rawPaths) : (rawPaths || [])
+        if (!paths.some(isLocalPath)) return
+
+        const supabase = getSupabaseClient()
+        const updatedPaths: string[] = []
+        let uploadedAny = false
+
+        for (const path of paths) {
+            if (!isLocalPath(path)) {
+                updatedPaths.push(path)
+                continue
+            }
+
+            try {
+                const fileInfo = await FileSystem.getInfoAsync(path)
+                if (!fileInfo.exists) {
+                    logWarn('[DeploymentPhotoService] Local photo missing, dropping:', path)
+                    uploadedAny = true // path list changed
+                    continue
+                }
+
+                const filename = path.split('/').pop() || `${Date.now()}.jpg`
+                const storagePath = `${deployment.projectId}/${deployment.id}/${filename}`
+                const base64 = await FileSystem.readAsStringAsync(path, {
+                    encoding: FileSystem.EncodingType.Base64,
+                })
+                const contentType = filename.endsWith('.png') ? 'image/png' : 'image/jpeg'
+
+                const { error } = await supabase.storage
+                    .from(BUCKET)
+                    .upload(storagePath, base64ToBytes(base64).buffer as ArrayBuffer, {
+                        contentType,
+                        upsert: true,
+                    })
+
+                if (error) throw error
+
+                log('[DeploymentPhotoService] Uploaded photo:', storagePath)
+                updatedPaths.push(storagePath)
+                uploadedAny = true
+                await DeploymentPhotoService.removeLocalPhoto(path)
+            } catch (e) {
+                logError('[DeploymentPhotoService] Upload failed, will retry later:', e)
+                updatedPaths.push(path) // keep local path for retry
+            }
+        }
+
+        if (!uploadedAny) return
+
+        await database.write(async () => {
+            const fresh = await deploymentsCollection.find(deploymentId)
+            const updateOp = fresh.prepareUpdate((record) => {
+                record.cameraLocationImagePaths = updatedPaths
+                record.modifiedBy = userId
+            })
+            const outboxOp = OutboxService.recordOperation({
+                operation: 'UPDATE',
+                tableName: 'deployments',
+                recordId: fresh.id,
+                payload: mapModelToPayload(fresh),
+                userId,
+            })
+            await database.batch(updateOp, outboxOp)
+        })
+
+        SupabaseSyncService.debouncedSync()
+    },
+
+    /**
+     * Try to upload pending photos for every deployment that still has
+     * local paths. Called opportunistically (e.g. after a sync).
+     */
+    uploadAllPending: async (userId: string): Promise<void> => {
+        const deploymentsCollection = database.get<Deployment>('deployments')
+        const deployments = await deploymentsCollection.query().fetch()
+        for (const deployment of deployments) {
+            const rawPaths = deployment.cameraLocationImagePaths
+            const paths: string[] = typeof rawPaths === 'string' ? JSON.parse(rawPaths) : (rawPaths || [])
+            if (paths.some(isLocalPath)) {
+                await DeploymentPhotoService.uploadPendingPhotos(deployment.id, userId)
+            }
+        }
+    },
+
+    /**
+     * Resolve a stored photo path to something an <Image> can display:
+     * local file URIs pass through, storage paths become signed URLs.
+     * Returns null when the photo cannot be resolved (e.g. offline).
+     */
+    getDisplayUrl: async (path: string): Promise<string | null> => {
+        if (isLocalPath(path)) return path
+        try {
+            const supabase = getSupabaseClient()
+            const { data, error } = await supabase.storage
+                .from(BUCKET)
+                .createSignedUrl(path, SIGNED_URL_TTL_SECONDS)
+            if (error || !data?.signedUrl) {
+                logWarn('[DeploymentPhotoService] Could not sign URL for', path, error?.message)
+                return null
+            }
+            return data.signedUrl
+        } catch (e) {
+            logWarn('[DeploymentPhotoService] Failed to resolve photo URL:', e)
+            return null
+        }
+    },
+
+    /**
+     * Resolve all photo paths of a deployment to displayable URLs.
+     */
+    getDisplayUrls: async (deployment: Deployment): Promise<string[]> => {
+        const rawPaths = deployment.cameraLocationImagePaths
+        const paths: string[] = typeof rawPaths === 'string' ? JSON.parse(rawPaths) : (rawPaths || [])
+        const urls = await Promise.all(paths.map((p) => DeploymentPhotoService.getDisplayUrl(p)))
+        return urls.filter((u): u is string => !!u)
+    },
+}
+
+export default DeploymentPhotoService

--- a/src/services/DeploymentService.ts
+++ b/src/services/DeploymentService.ts
@@ -380,9 +380,12 @@ export const DeploymentService = {
 }
 
 /**
- * Helper to map model to plain object for sync (snake_case)
+ * Helper to map model to plain object for sync (snake_case).
+ * Exported because sync payloads must always be complete records:
+ * push_changes overwrites every column, so partial payloads would
+ * null out the missing fields.
  */
-function mapModelToPayload(model: Deployment): any {
+export function mapModelToPayload(model: Deployment): any {
     return {
         id: model.id,
         project_id: model.projectId,

--- a/src/services/SupabaseSyncService.ts
+++ b/src/services/SupabaseSyncService.ts
@@ -207,6 +207,17 @@ class SupabaseSyncService {
                 // log(`✅ Sync completed successfully in ${syncDuration}ms (total syncs: ${syncCount})`)
             })
 
+            // Retry any deployment photos still waiting to reach storage
+            // (lazy import: DeploymentPhotoService depends on this service)
+            try {
+                const { DeploymentPhotoService } = await import('./DeploymentPhotoService')
+                DeploymentPhotoService.uploadAllPending(user.id).catch((e: unknown) =>
+                    logWarn('⚠️ [SupabaseSyncService] Pending photo upload failed:', e)
+                )
+            } catch (e) {
+                logWarn('⚠️ [SupabaseSyncService] Could not start photo upload:', e)
+            }
+
             // Mark initial sync complete — routing decisions in the scanner are now valid
             if (this.store) {
                 try {


### PR DESCRIPTION
Lets users photograph the camera in place when starting monitoring, and shows those photos to everyone in the project so the camera is easy to find again. Photos live in the new deployment-photos storage bucket ({project_id}/{deployment_id}/{filename}); the deployment record keeps the paths in camera_location_image_paths, which already syncs.

- expo-image-picker added (plugin configured; iOS permission strings already existed in app.config.ts)
- DeploymentPhotosSection on Start Monitoring: take/pick up to 5 photos, thumbnail grid with remove
- DeploymentPhotoService: persists picked images to app storage, uploads pending file:// photos to the bucket, swaps in storage paths on the record (full-payload outbox update), resolves signed display URLs
- Offline-first: photos are stored locally at creation; uploads run in the background after deployment creation and retry after every successful sync
- DeploymentPhotoStrip on the map DeploymentCard, disk-cached by storage path so photos stay visible offline once seen