### PR TITLE
feat(defaults): enable auto day/night camera switching, raise md ir b…

### DIFF
--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -12,7 +12,7 @@
 import { appSchema, tableSchema } from '@nozbe/watermelondb'
 
 export default appSchema({
-    version: 396,
+    version: 399,
     tables: [
         tableSchema({
             name: 'account_deletion_requests',
@@ -338,6 +338,28 @@ export default appSchema({
                 { name: 'deployment_comments', type: 'string', isOptional: true },
                 { name: 'camera_location_description', type: 'string', isOptional: true },
                 { name: 'camera_location_image_path', type: 'string', isOptional: true },
+                // System & Sync Fields
+                { name: 'created_at', type: 'number' },
+                { name: 'updated_at', type: 'number' },
+                { name: 'deleted_at', type: 'number' },
+                { name: '_version', type: 'number' },
+                { name: '_custom_sync_status', type: 'string', isOptional: true },
+                { name: 'modified_by', type: 'string' },
+            ],
+        }),
+        tableSchema({
+            name: 'device_alert_rules',
+            columns: [
+                { name: 'backoff_steps_min', type: 'string' },
+                { name: 'clear_window_min', type: 'number' },
+                { name: 'created_by', type: 'string', isOptional: true },
+                { name: 'digest_send_utc', type: 'number', isOptional: true },
+                { name: 'enabled', type: 'boolean' },
+                { name: 'label', type: 'string' },
+                { name: 'mode', type: 'string' },
+                { name: 'model_family_id', type: 'string', isIndexed: true },
+                { name: 'project_id', type: 'string', isIndexed: true },
+                { name: 'threshold_pct', type: 'number' },
                 // System & Sync Fields
                 { name: 'created_at', type: 'number' },
                 { name: 'updated_at', type: 'number' },
@@ -680,6 +702,7 @@ export default appSchema({
         tableSchema({
             name: 'observations',
             columns: [
+                { name: 'ai_origin', type: 'string', isOptional: true },
                 { name: 'annotator_id', type: 'string', isOptional: true, isIndexed: true },
                 { name: 'bbox_h', type: 'number', isOptional: true },
                 { name: 'bbox_w', type: 'number', isOptional: true },

--- a/src/hooks/useDeviceSettings.ts
+++ b/src/hooks/useDeviceSettings.ts
@@ -85,11 +85,18 @@ export const FACTORY_DEFAULTS: Record<number, number> = {
     [OP_PARAMETER.IMAGES_COUNT]: 0,
     [OP_PARAMETER.IMAGES_FILE_INDEX]: 0,
     [OP_PARAMETER.MD_FLASH_LED]: 2,
-    [OP_PARAMETER.MD_FLASH_BRIGHTNESS_PERCENT]: 5,
+    // 50%: bench 5% was too dim for night-time motion detection at typical
+    // camera-to-subject distances. The IR LED only fires during each MD
+    // frame's integration window (HM0360 STROBE-gated, ~15 ms pulses).
+    [OP_PARAMETER.MD_FLASH_BRIGHTNESS_PERCENT]: 50,
     [OP_PARAMETER.AE_DARK_THRESHOLD]: 65,
     [OP_PARAMETER.AE_CHECK_INTERVAL]: 15,
     [OP_PARAMETER.AE_FLASH_STATE]: 0,
-    [OP_PARAMETER.SLOT_SWITCH]: 0,
+    // 1 = automatic day/night camera switching after each AE light check.
+    // resetOps diff-writes this during every deployment, so monitoring runs
+    // switch cameras with the light. Requires both firmware slots labelled
+    // (a dual-image update leaves them so).
+    [OP_PARAMETER.SLOT_SWITCH]: 1,
     [OP_PARAMETER.WB_RED_GAIN]: 286,
     [OP_PARAMETER.WB_BLUE_GAIN]: 326,
 }

--- a/src/screens/Deployments/hooks/useStartDeployment.ts
+++ b/src/screens/Deployments/hooks/useStartDeployment.ts
@@ -577,6 +577,67 @@ export const useStartDeployment = ({
                 logWarn('[Deployment] Failed to set capture format (non-fatal):', formatError)
             }
 
+            // 7c. One-shot light check: take a single reference photo (every capture
+            // runs the AE light check on-device and persists the decision to op25),
+            // then read the verdict back and tell the user which camera mode the
+            // deployment starts in and when light is re-checked. Non-fatal: on any
+            // failure fall back to the last persisted decision from the pre-flight
+            // ops snapshot.
+            try {
+                progress.addLog('Checking light conditions...')
+                progress.setFinishStep('Checking light...')
+                progress.setFinishProgress(0.9)
+
+                let flashState: number | null = null
+                let checkInterval: number | null = null
+                let autoSwitch: number | null = null
+                let freshReading = false
+
+                try {
+                    // One photo; its AE sample refreshes op25 (and doubles as a
+                    // deployment-start reference shot on the SD card).
+                    await bleSession?.execute(() => commandRegistry.capture(1, 500))
+                    const opsAfter = await bleSession?.execute(commandRegistry.getops)
+                    if (opsAfter) {
+                        flashState = parseInt(opsAfter[OP_PARAMETER.AE_FLASH_STATE] ?? '', 10)
+                        checkInterval = parseInt(opsAfter[OP_PARAMETER.AE_CHECK_INTERVAL] ?? '', 10)
+                        autoSwitch = parseInt(opsAfter[OP_PARAMETER.SLOT_SWITCH] ?? '', 10)
+                        freshReading = !isNaN(flashState)
+                    }
+                } catch (captureError) {
+                    logWarn('[Deployment] Light-check capture failed, using last known decision:', captureError)
+                }
+
+                if (!freshReading) {
+                    // Pre-reset snapshot: op25 persists across sleep, so the last
+                    // session's decision is still meaningful, just not fresh.
+                    flashState = parseInt(currentOps[OP_PARAMETER.AE_FLASH_STATE] ?? '', 10)
+                    checkInterval = parseInt(currentOps[OP_PARAMETER.AE_CHECK_INTERVAL] ?? '', 10)
+                    autoSwitch = parseInt(currentOps[OP_PARAMETER.SLOT_SWITCH] ?? '', 10)
+                }
+
+                if (flashState !== null && !isNaN(flashState)) {
+                    const dark = flashState === 1
+                    const readingTag = freshReading ? 'Light check' : 'Light check (last known reading)'
+                    progress.addLog(dark
+                        ? `💡 ${readingTag}: DARK — starting in night mode (IR camera)`
+                        : `💡 ${readingTag}: BRIGHT — starting in day mode (colour camera)`)
+
+                    const intervalKnown = checkInterval !== null && !isNaN(checkInterval)
+                    if (autoSwitch === 1) {
+                        progress.addLog(intervalKnown && checkInterval! > 0
+                            ? `Light is re-checked after every photo and every ${checkInterval} min while asleep — the camera switches day/night automatically at the next sleep.`
+                            : 'Light is re-checked after every photo — the camera switches day/night automatically at the next sleep.')
+                    } else {
+                        progress.addLog('Auto day/night switching is OFF — the device stays in this camera mode.')
+                    }
+                } else {
+                    progress.addLog('Light conditions unknown — the device will decide day/night on its first capture.')
+                }
+            } catch (lightError) {
+                logWarn('[Deployment] Light check failed (non-fatal):', lightError)
+            }
+
             progress.setFinishStep('Complete')
             progress.setFinishProgress(1.0)
             progress.setIsSuccess(true)

--- a/src/screens/Devices/hooks/useFirmwareStatus.ts
+++ b/src/screens/Devices/hooks/useFirmwareStatus.ts
@@ -36,6 +36,29 @@ export interface UseFirmwareStatusReturn {
     errorMsg: string | null
 }
 
+/**
+ * Dual-image aware outdated check — the same rule as the update screen's
+ * `deviceUpToDate`. RP3 and HM0360 builds carry different version strings and
+ * the device only runs one of them, so it is up to date when its version
+ * matches EITHER variant's latest. Comparing against the single newest
+ * 'himax' row flagged "outdated" whenever the newest upload happened to be
+ * the other camera's build. An unknown current version is not outdated
+ * (unknown is not actionable — the card should not cry wolf).
+ */
+const isHimaxOutdated = (
+    current: string | null,
+    latestRp3: Firmware | null,
+    latestHm0360: Firmware | null,
+    latestGeneric: Firmware | null,
+): boolean => {
+    if (!current) return false
+    const cur = current.trim()
+    const variantVersions = [latestRp3?.version?.trim(), latestHm0360?.version?.trim()]
+        .filter((v): v is string => !!v)
+    if (variantVersions.length > 0) return !variantVersions.includes(cur)
+    return !!latestGeneric?.version && cur !== latestGeneric.version.trim()
+}
+
 export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersion }: UseFirmwareStatusOptions): UseFirmwareStatusReturn {
     const [isChecking, setIsChecking] = useState(false)
     const [lastChecked, setLastChecked] = useState<Date | null>(null)
@@ -101,9 +124,9 @@ export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersi
 
             if (!isMounted.current) return
 
-            // 3. Compute Outdated Flags
+            // 3. Compute Outdated Flags (himax: variant-aware, see isHimaxOutdated)
             const bleOutdated = !!latestBle?.version && currentBleVersion !== latestBle.version
-            const himaxOutdated = !!latestHimax?.version && currentHimaxVersion !== latestHimax.version
+            const himaxOutdated = isHimaxOutdated(currentHimaxVersion, latestRp3, latestHm0360, latestHimax)
 
             setStatuses({
                 ble: {
@@ -153,6 +176,8 @@ export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersi
                     try {
                         const latestBle = await ReferenceDataService.getLatestFirmware('ble')
                         const latestHimax = await ReferenceDataService.getLatestFirmware('himax')
+                        const latestRp3 = await ReferenceDataService.getLatestHimaxByVariant('RP3')
+                        const latestHm0360 = await ReferenceDataService.getLatestHimaxByVariant('HM0360')
 
                         const currentBleVersion = convertBleToSemanticVersion(initialBleVersion)
                         const rawHimaxVer = initialHimaxVersion
@@ -160,9 +185,20 @@ export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersi
                         const currentHimaxVersion = match ? `v${match[1]}` : rawHimaxVer
 
                         const bleOutdated = !!latestBle?.version && currentBleVersion !== latestBle.version
-                        const himaxOutdated = !!latestHimax?.version && currentHimaxVersion !== latestHimax.version
+                        const himaxOutdated = isHimaxOutdated(currentHimaxVersion, latestRp3, latestHm0360, latestHimax)
 
                         if (!isMounted.current) return
+
+                        // The initial versions are a connect-time snapshot — stale
+                        // right after a firmware update. Never declare "outdated"
+                        // from the snapshot alone: escalate to the active check
+                        // (live `version`/`AI ver` queries) and let the device
+                        // decide. Up-to-date verdicts stay silent and BLE-quiet.
+                        if (bleOutdated || himaxOutdated) {
+                            logWarn('[FirmwareStatus] Snapshot looks outdated — verifying against the live device')
+                            await checkStatus()
+                            return
+                        }
 
                         setStatuses({
                             ble: {
@@ -178,6 +214,7 @@ export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersi
                                 latestVersion: latestHimax?.version || 'Unknown',
                                 latestFirmware: latestHimax,
                                 isOutdated: himaxOutdated,
+                                variants: { RP3: latestRp3, HM0360: latestHm0360 },
                             },
                         })
                         setLastChecked(new Date())

--- a/src/screens/Devices/hooks/useFirmwareUpdate.ts
+++ b/src/screens/Devices/hooks/useFirmwareUpdate.ts
@@ -83,7 +83,7 @@ const HIMAX_PHASE_LABELS: Record<UpdatePhase, string> = {
     transferring: 'Transferring firmware to SD card...',
     sending: 'Sending firmware update command...',
     waking: 'AI processor waking up...',
-    flashing: 'Writing firmware to flash...',
+    flashing: 'Writing firmware to flash — typically 5-10 min...',
     rebooting: 'Rebooting AI processor (takes 6-10s)...',
     reconnecting: 'Reconnecting to device...',
     verifying: 'Verifying new firmware version...',
@@ -270,6 +270,12 @@ export function useFirmwareUpdate({ target, device }: UseFirmwareUpdateOptions) 
 
     const [phase, setPhase] = useState<UpdatePhase>('idle')
     const [dfuProgress, setDfuProgress] = useState(0) // 0-100 for BLE DFU
+    // Elapsed seconds since the Himax flash command went out. The device is
+    // silent over BLE for the whole erase+write+verify (its progress prints go
+    // to the local UART console only — see firmware xip_manager.c), so a
+    // ticking clock is the honest "still working" signal during that window.
+    const flashStartRef = useRef<number | null>(null)
+    const [flashElapsedSec, setFlashElapsedSec] = useState(0)
     const [fileTransferProgress, setFileTransferProgress] = useState<FileTransferProgress | null>(null)
     const [isUpdating, setIsUpdating] = useState(false)
     const [errorMsg, setErrorMsg] = useState<string | null>(null)
@@ -491,6 +497,19 @@ export function useFirmwareUpdate({ target, device }: UseFirmwareUpdateOptions) 
         return () => { bleEventBus.removeListener('textLine', onRx) }
     }, [target, isUpdating, device?.id, advancePhase, appendLog])
 
+    // ── Himax flash elapsed clock ──────────────────────────────────
+    // Ticks once a second while the flash command is in flight (waking /
+    // flashing), driving the "(m:ss elapsed)" suffix on the status label.
+    useEffect(() => {
+        if (target !== 'himax' || !isUpdating || (phase !== 'waking' && phase !== 'flashing')) return
+        const id = setInterval(() => {
+            if (flashStartRef.current !== null && !unmountedRef.current) {
+                setFlashElapsedSec(Math.floor((Date.now() - flashStartRef.current) / 1000))
+            }
+        }, 1000)
+        return () => clearInterval(id)
+    }, [target, isUpdating, phase])
+
 
     // ── BLE DFU flow ───────────────────────────────────────────────
 
@@ -674,7 +693,20 @@ export function useFirmwareUpdate({ target, device }: UseFirmwareUpdateOptions) 
             advancePhase('sending')
             appendLog(`${passLabel}Sending firmware flash command...`)
 
-            await session.execute(() => commandRegistry.aifirmware(imgName, computedCrc))
+            // The device reports nothing over BLE while it erases/writes flash
+            // (its progress prints go to the local UART console only); the next
+            // line we receive is the final "Firmware update OK/FAILED", minutes
+            // later. Start the elapsed clock and advance to 'flashing' after a
+            // short grace so the UI never sits frozen on "waking up".
+            flashStartRef.current = Date.now()
+            setFlashElapsedSec(0)
+            const flashPhaseTimer = setTimeout(() => advancePhase('flashing'), 8000)
+            try {
+                await session.execute(() => commandRegistry.aifirmware(imgName, computedCrc))
+            } finally {
+                clearTimeout(flashPhaseTimer)
+                flashStartRef.current = null
+            }
         } else {
             // Source is 'sdcard'
             advancePhase('sending')
@@ -685,7 +717,16 @@ export function useFirmwareUpdate({ target, device }: UseFirmwareUpdateOptions) 
                 appendLog(`${passLabel}Using database CRC for flash: ${targetCrc}`)
             }
 
-            await session.execute(() => commandRegistry.aifirmware(filenameToFlash, targetCrc))
+            // Same silent-flash window as the download path (see above).
+            flashStartRef.current = Date.now()
+            setFlashElapsedSec(0)
+            const flashPhaseTimer = setTimeout(() => advancePhase('flashing'), 8000)
+            try {
+                await session.execute(() => commandRegistry.aifirmware(filenameToFlash, targetCrc))
+            } finally {
+                clearTimeout(flashPhaseTimer)
+                flashStartRef.current = null
+            }
         }
 
         if (unmountedRef.current) return
@@ -962,6 +1003,13 @@ export function useFirmwareUpdate({ target, device }: UseFirmwareUpdateOptions) 
         statusLabel = interPassWait
             ? `Image ${pairProgress.done} of ${pairProgress.total} installed — waiting for the camera to restart…`
             : `[Image ${Math.min(pairProgress.done + 1, pairProgress.total)} of ${pairProgress.total}] ${labels[phase]}`
+    }
+    // While the Himax writes flash the phone hears nothing over BLE — show a
+    // ticking elapsed clock so the long quiet window reads as work, not a hang.
+    if (target === 'himax' && isUpdating && (phase === 'waking' || phase === 'flashing') && flashElapsedSec > 0) {
+        const mm = Math.floor(flashElapsedSec / 60)
+        const ss = String(flashElapsedSec % 60).padStart(2, '0')
+        statusLabel = `${statusLabel} (${mm}:${ss} elapsed)`
     }
 
     // For BLE DFU and Himax File Transfer, interpolate real progress during specific phases

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1304,6 +1304,97 @@ export type Database = {
           },
         ]
       }
+      device_alert_rules: {
+        Row: {
+          backoff_steps_min: number[]
+          clear_window_min: number
+          created_at: string | null
+          created_by: string | null
+          digest_send_utc: number | null
+          enabled: boolean
+          id: string
+          label: string
+          mode: string
+          model_family_id: string
+          project_id: string
+          threshold_pct: number
+          updated_at: string | null
+        }
+        Insert: {
+          backoff_steps_min?: number[]
+          clear_window_min?: number
+          created_at?: string | null
+          created_by?: string | null
+          digest_send_utc?: number | null
+          enabled?: boolean
+          id?: string
+          label: string
+          mode: string
+          model_family_id: string
+          project_id: string
+          threshold_pct?: number
+          updated_at?: string | null
+        }
+        Update: {
+          backoff_steps_min?: number[]
+          clear_window_min?: number
+          created_at?: string | null
+          created_by?: string | null
+          digest_send_utc?: number | null
+          enabled?: boolean
+          id?: string
+          label?: string
+          mode?: string
+          model_family_id?: string
+          project_id?: string
+          threshold_pct?: number
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "device_alert_rules_model_family_id_fkey"
+            columns: ["model_family_id"]
+            isOneToOne: false
+            referencedRelation: "ai_model_families"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "device_alert_rules_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "deployment_overview"
+            referencedColumns: ["project_id"]
+          },
+          {
+            foreignKeyName: "device_alert_rules_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "project_members_detailed"
+            referencedColumns: ["project_id"]
+          },
+          {
+            foreignKeyName: "device_alert_rules_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "project_summary"
+            referencedColumns: ["project_id"]
+          },
+          {
+            foreignKeyName: "device_alert_rules_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "device_alert_rules_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects_with_stats"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       devices: {
         Row: {
           bluetooth_id: string
@@ -2622,6 +2713,7 @@ export type Database = {
       }
       observations: {
         Row: {
+          ai_origin: string | null
           annotator_id: string | null
           bbox_h: number | null
           bbox_w: number | null
@@ -2662,6 +2754,7 @@ export type Database = {
           vernacular_name: string | null
         }
         Insert: {
+          ai_origin?: string | null
           annotator_id?: string | null
           bbox_h?: number | null
           bbox_w?: number | null
@@ -2702,6 +2795,7 @@ export type Database = {
           vernacular_name?: string | null
         }
         Update: {
+          ai_origin?: string | null
           annotator_id?: string | null
           bbox_h?: number | null
           bbox_w?: number | null

--- a/supabase/schemas/public/tables/35_observations.sql
+++ b/supabase/schemas/public/tables/35_observations.sql
@@ -54,6 +54,10 @@ CREATE TABLE observations (
 
   -- Provenance (traceable lineage)
   source_type text CHECK (source_type IS NULL OR (source_type IN ('ai', 'human', 'imported', 'consensus'))),
+  -- For source_type='ai': which AI layer produced the row. 'edge' = the camera's
+  -- on-device model (ingested from EXIF UserComment); 'cloud' = the website
+  -- pipeline (SpeciesNet/BioCLIP). NULL for human/imported/consensus rows.
+  ai_origin text CHECK (ai_origin IS NULL OR (ai_origin IN ('edge', 'cloud'))),
   source_model_id uuid REFERENCES ai_models (id) ON DELETE SET NULL,
   source_model_version text,
   annotator_id uuid REFERENCES users (id) ON DELETE SET NULL,
@@ -104,6 +108,7 @@ COMMENT ON COLUMN observations.scientific_name IS 'Denormalised scientific name 
 COMMENT ON COLUMN observations.crop_url IS 'Per-observation bounding-box crop in Supabase Storage (media-renditions bucket). One crop per detection, complementing media_assets.animal_crop_url (the single hero crop). NULL for whole-image/blank observations.';
 COMMENT ON COLUMN observations.vernacular_name IS 'Denormalised common name (e.g. North Island Brown Kiwi).';
 COMMENT ON COLUMN observations.source_type IS 'Indicates whether the label came from AI, human review, imported packages, or consensus voting.';
+COMMENT ON COLUMN observations.ai_origin IS 'AI layer that produced an ai-sourced row: edge (camera on-device model, via EXIF) or cloud (website SpeciesNet/BioCLIP pipeline). NULL for non-AI rows.';
 COMMENT ON COLUMN observations.source_model_id IS 'AI model reference if generated automatically.';
 COMMENT ON COLUMN observations.annotator_id IS 'Authenticating user ID who labeled this record.';
 COMMENT ON COLUMN observations.reviewer_id IS 'Authenticating user ID who verified this record.';

--- a/supabase/schemas/public/tables/57_device_alert_rules.sql
+++ b/supabase/schemas/public/tables/57_device_alert_rules.sql
@@ -1,0 +1,68 @@
+-- *** Device Alert Rules ***
+--
+-- Per-project LoRaWAN alerting configuration for the camera's on-device (edge) model.
+-- Rules are compiled into the device config by the website manifest job — the label is
+-- resolved to the deployed model version's output class index at compile time — and
+-- drive what the camera transmits over LoRaWAN: instant alerts, a daily digest, or
+-- smart back-off (alert immediately, then progressively suppress while the target
+-- remains present; reset after a quiet window).
+--
+-- Distinct from notification_rules (per-USER delivery preferences, cloud side):
+-- device_alert_rules decide what the DEVICE transmits; notification_rules decide who
+-- is told once the decoded uplink reaches the backend.
+
+CREATE TABLE device_alert_rules (
+  id uuid PRIMARY KEY NOT NULL DEFAULT (gen_random_uuid()),
+  created_at timestamptz DEFAULT (now()),
+  updated_at timestamptz DEFAULT (now()),
+  created_by uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+
+  project_id uuid NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+  model_family_id uuid NOT NULL REFERENCES ai_model_families (id) ON DELETE CASCADE,
+
+  -- Output class this rule fires on. Must name a role='target' label in the deployed
+  -- version's ai_models.label_map (validated at manifest compile time, not by FK).
+  label text NOT NULL,
+
+  mode text NOT NULL CHECK (mode IN ('instant', 'digest', 'backoff')),
+  threshold_pct smallint NOT NULL DEFAULT 80 CHECK (threshold_pct BETWEEN 1 AND 100),
+
+  -- digest only: UTC hour of the daily digest uplink.
+  digest_send_utc smallint CHECK (digest_send_utc BETWEEN 0 AND 23),
+
+  -- backoff only: suppression steps applied after each alert, and the quiet window
+  -- (no detections) that resets the sequence. Defaults: 5 min -> 30 min -> 2 h -> 12 h.
+  backoff_steps_min integer [] NOT NULL DEFAULT '{5,30,120,720}',
+  clear_window_min integer NOT NULL DEFAULT 60 CHECK (clear_window_min > 0),
+
+  enabled boolean NOT NULL DEFAULT true,
+
+  UNIQUE (project_id, model_family_id, label),
+
+  -- digest_send_utc is only meaningful for digest rules.
+  CONSTRAINT chk_alert_digest_hour CHECK (mode = 'digest' OR digest_send_utc IS null)
+);
+
+CREATE INDEX idx_device_alert_rules_project
+  ON device_alert_rules (project_id) WHERE enabled;
+
+COMMENT ON TABLE device_alert_rules IS
+    'Per-project LoRaWAN alert configuration for the on-device (edge) model. '
+    'Compiled into the device config by the manifest job (label resolved to a class '
+    'index); the Nordic firmware executes the instant/digest/backoff strategies. '
+    'Complements notification_rules, which govern per-user delivery on the cloud side.';
+COMMENT ON COLUMN device_alert_rules.label IS 'Model output class the rule fires on; must be a target label in the deployed version''s label_map.';
+COMMENT ON COLUMN device_alert_rules.mode IS 'instant = uplink per qualifying detection (rate-limited); digest = one daily summary; backoff = immediate first alert then progressive suppression.';
+COMMENT ON COLUMN device_alert_rules.threshold_pct IS 'Minimum confidence (percent) for a detection to qualify. Converted to device logit units at manifest compile time using the model''s output quantization.';
+COMMENT ON COLUMN device_alert_rules.digest_send_utc IS 'digest mode only: UTC hour (0-23) at which the daily digest uplink is sent.';
+COMMENT ON COLUMN device_alert_rules.backoff_steps_min IS 'backoff mode only: minutes of suppression after each successive alert while the target remains present.';
+COMMENT ON COLUMN device_alert_rules.clear_window_min IS 'backoff mode only: minutes without a qualifying detection before the sequence resets (next detection alerts instantly again).';
+
+ALTER TABLE device_alert_rules ENABLE ROW LEVEL SECURITY;
+
+-- Project members read; project admins manage (policies restrict, see
+-- yyy_policies/93_device_alert_rules.sql). The manifest job and LoRaWAN decoder
+-- read with the service role.
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.device_alert_rules TO authenticated;
+
+GRANT ALL ON public.device_alert_rules TO service_role;


### PR DESCRIPTION
…rightness to 50 percent

- SLOT_SWITCH (op26) factory default 0 -> 1: resetOps diff-writes the factory defaults during every deployment, so monitoring runs now switch cameras automatically after each 15-min AE light check. requires both firmware slots labelled - a dual-image update leaves them so
- MD_FLASH_BRIGHTNESS_PERCENT (op22) 5 -> 50: bench value was too dim for night-time motion detection. the ir led remains strobe-gated to each md frame integration window (~15ms pulses), so duty cycle stays low