### PR TITLE
fix(ble): iOS large-file transfer dies at ~6% — use write-with-response on iOS

### DIFF
--- a/src/ble/protocol/fileTransfer/runFileTransferPipeline.ts
+++ b/src/ble/protocol/fileTransfer/runFileTransferPipeline.ts
@@ -109,6 +109,20 @@ export async function runFileTransferPipeline(
   // fails fast with an ftx error (prompting the BLE firmware update) rather
   // than hanging. Callers should only override this for protocol testing.
   const windowSize = requestedWindowSize ?? 12
+
+  // iOS: use write-WITH-response for every transfer packet. CoreBluetooth
+  // silently DISCARDS .withoutResponse writes when its transmit queue is full,
+  // and react-native-ble-manager (11.x) never checks canSendWriteWithoutResponse
+  // nor waits for peripheralIsReadyToSendWriteWithoutResponse - so once iOS
+  // relaxes the connection interval (~30s in, and there is no iOS API to hold
+  // it fast), a window burst overruns the queue and packets vanish with no
+  // error. The strictly-ordered nRF->HX pipeline then waits forever for the
+  // gap and the transfer dies at DEVICE_SILENT (bench 16 Jul 2026: large
+  // binary stalled at ~packet 120 / 6%; TINY.TXT unaffected). ATT
+  // write-with-response provides the per-packet flow control iOS refuses to
+  // expose - slower, but drops become impossible by protocol. Android keeps
+  // the tuned without-response fast path.
+  const writeWithResponse = Platform.OS === 'ios'
   const transferId = generateTransferId()
   const startTime = Date.now()
 
@@ -376,7 +390,7 @@ export async function runFileTransferPipeline(
         const fileStartT0 = Date.now()
         const startAckPromise = prepareAckWait({ phase: 'start' }, FILE_START_ACK_TIMEOUT_MS)
         if (isDisconnected) throw new FileTransferError('DISCONNECTED', 'Device disconnected before FILE_START')
-        await writeBinaryToDevice(peripheral, startPacket, false)
+        await writeBinaryToDevice(peripheral, startPacket, writeWithResponse)
         log(`[FileTransfer] FILE_START sent: ${filename} (${data.length} bytes) [attempt ${sessionAttempt + 1}]`)
 
         await startAckPromise
@@ -419,7 +433,7 @@ export async function runFileTransferPipeline(
             currentAckStartTime = Date.now()
             currentAckPromise = prepareAckWait({ phase: 'data', packetNum: pkt.wireNum })
             if (isDisconnected) throw new FileTransferError('DISCONNECTED', 'Device disconnected before write')
-            await writeBinaryToDevice(peripheral, pkt.packet, false)
+            await writeBinaryToDevice(peripheral, pkt.packet, writeWithResponse)
           }
 
           while (i < preBuiltPackets.length) {
@@ -439,7 +453,7 @@ export async function runFileTransferPipeline(
                 wirePacketNum = next.wireNum
                 currentAckStartTime = Date.now()
                 currentAckPromise = prepareAckWait({ phase: 'data', packetNum: next.wireNum })
-                await writeBinaryToDevice(peripheral, next.packet, false)
+                await writeBinaryToDevice(peripheral, next.packet, writeWithResponse)
               }
 
               // ── ACCOUNTING (next write is already in BLE stack) ────
@@ -472,7 +486,7 @@ export async function runFileTransferPipeline(
               wirePacketNum = pkt.wireNum
               currentAckStartTime = Date.now()
               currentAckPromise = prepareAckWait({ phase: 'data', packetNum: pkt.wireNum })
-              await writeBinaryToDevice(peripheral, pkt.packet, false)
+              await writeBinaryToDevice(peripheral, pkt.packet, writeWithResponse)
             }
           }
         } else {
@@ -553,7 +567,7 @@ export async function runFileTransferPipeline(
               // responding"). The real throughput limiter was JS-thread congestion
               // from per-ack Engineer-Console logging, fixed in useBleListeners.
               while (nextToSend < total && (nextToSend - (highestAckedIndex + 1)) < windowSize) {
-                await writeBinaryToDevice(peripheral, preBuiltPackets[nextToSend].packet, false)
+                await writeBinaryToDevice(peripheral, preBuiltPackets[nextToSend].packet, writeWithResponse)
                 nextToSend++
               }
 
@@ -594,7 +608,7 @@ export async function runFileTransferPipeline(
         const fileEndT0 = Date.now()
         const endAckPromise = prepareAckWait({ phase: 'end' })
         if (isDisconnected) throw new FileTransferError('DISCONNECTED', 'Device disconnected before FILE_END')
-        await writeBinaryToDevice(peripheral, endPacket, false)
+        await writeBinaryToDevice(peripheral, endPacket, writeWithResponse)
         log(`[FileTransfer] FILE_END sent: CRC=0x${crc.toString(16).toUpperCase().padStart(4, '0')}`)
 
         await endAckPromise


### PR DESCRIPTION
## Problem

On iOS, large BLE file transfers die consistently at ~packet 120 (6%) with `Transfer failed: no transfer response for 15 seconds — device may be stuck`. Small files (TINY.TXT) succeed. Seen on app 0.0.58 with firmware `ww500_C02 Jul 16 2026` — but neither is at fault, and **the device is never actually stuck**.

## Root cause (verified in library source)

- CoreBluetooth **silently discards** `.withoutResponse` writes when its transmit queue is full — no error reaches JS.
- `react-native-ble-manager@11.3.2`'s iOS `writeWithoutResponse` calls `writeValue(_, type: .withoutResponse)` unconditionally — it never checks `canSendWriteWithoutResponse` nor waits for `peripheralIsReadyToSendWriteWithoutResponse` (see `ios/BleManager.swift`).
- The transfer's credit-streaming loop bursts up to 12 packets back-to-back. Early on, iOS grants a fast connection interval and keeps up. Once iOS relaxes the interval (~30 s in — and unlike Android's `requestConnectionPriority`, **no iOS API exists to hold it fast**), the queue overruns and a packet vanishes invisibly.
- The nRF→HX pipeline processes wire numbers strictly in order: the missing packet stalls all further acks → the app's window jams → 15 s silence → `DEVICE_SILENT`, blaming the wrong end.
- Small files never outrun the queue, which is why TINY.TXT passes.

## Fix

On iOS, send every transfer packet (FILE_START / DATA / END) **write-WITH-response**: ATT-level flow control confirms each write before the next goes out, making drops impossible by protocol. Android keeps its tuned without-response fast path unchanged — zero behavioural difference there.

Throughput trade-off on iOS: ~1 write per connection event (~4–8 KB/s expected), comparable to Android's measured 1.5–8 KB/s average, and infinitely better than dying at 6%.

## Verify

- `tsc --noEmit` ✅, eslint ✅.
- iOS retest plan: same large binary → steady progress past 6% at a slower-but-honest rate; TINY.TXT still instant; Android byte-identical to today.

## Considered and rejected

- **Pacing/smaller window on iOS** — heuristic; still drops when the interval decays further.
- **Patching RNBM to honour `peripheralIsReadyToSendWriteWithoutResponse`** — the correct upstream fix, but a native patch with regression risk vs. a contained 6-call-site app change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
