### PR TITLE
chore: bump mobile app version to 0.0.60

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId 'com.wildlife.wildlifewatcher'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 59
-        versionName "0.0.59"
+        versionCode 60
+        versionName "0.0.60"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
         

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,5 +3,5 @@
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">light</string>
-  <string name="expo_runtime_version">0.0.58</string>
+  <string name="expo_runtime_version">0.0.60</string>
 </resources>

--- a/app.config.ts
+++ b/app.config.ts
@@ -26,7 +26,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     ios: {
         supportsTablet: true,
         bundleIdentifier: BUNDLE_ID,
-        buildNumber: "59",
+        buildNumber: "60",
         config: {
             googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY_IOS,
         },
@@ -45,7 +45,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     },
     android: {
         package: BUNDLE_ID,
-        versionCode: 59,
+        versionCode: 60,
         adaptiveIcon: {
             foregroundImage: "./assets/adaptive-icon.png",
             backgroundColor: "#ffffff"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wildlifewatcher",
-  "version": "0.0.58",
+  "version": "0.0.60",
   "private": true,
   "scripts": {
     "android": "npm run types:cloud-dev && npm run db:sync-schema && npm run schema:generate && npx expo run:android",


### PR DESCRIPTION
## Summary

Version bump to **0.0.60** across every version-bearing file, per `.agents/skills/SKILL.md` §9 (Release Version Rules):

| File | Field | Before | After |
|---|---|---|---|
| `package.json` | `version` (drives Expo `version` + `runtimeVersion`) | **0.0.58** | 0.0.60 |
| `app.config.ts` | `ios.buildNumber` | 59 | 60 |
| `app.config.ts` | `android.versionCode` | 59 | 60 |
| `android/app/build.gradle` | `versionCode` / `versionName` | 59 / 0.0.59 | 60 / 0.0.60 |
| `android/.../values/strings.xml` | `expo_runtime_version` | 0.0.58 | 0.0.60 |

## Also heals a latent inconsistency

The 0.0.59 bump (#208) updated `app.config.ts` + gradle but **missed `package.json`** — so versionCode-59 builds displayed and runtime-versioned as **0.0.58** (this is why the app on the bench reports 0.0.58). All five fields now agree; store submissions and OTA runtime-version matching are consistent again.

## Validation

`tsc --noEmit` ✅ (per SKILL.md §8). Native Android config synchronized in the same commit (§9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
