### PR TITLE
feat(deployment): high-resolution photo toggle in Advanced Settings

### DIFF
--- a/src/screens/Deployments/StartMonitoringScreen.tsx
+++ b/src/screens/Deployments/StartMonitoringScreen.tsx
@@ -54,6 +54,7 @@ export const StartMonitoringDetailsStep = () => {
         batteryLevel, sdCardStatus,
         handleBatteryCheck, handleSdCardCheck,
         recordJpegOnly, setRecordJpegOnly,
+        hiResPhotos, setHiResPhotos,
         isMonitoring, handleMonitorDisconnect, handleStopMonitoring, isStoppingMonitoring,
         deploymentStartTime,
         // DFU control
@@ -360,6 +361,8 @@ export const StartMonitoringDetailsStep = () => {
                     handleSdCardCheck={handleSdCardCheck}
                     recordJpegOnly={recordJpegOnly}
                     setRecordJpegOnly={setRecordJpegOnly}
+                    hiResPhotos={hiResPhotos}
+                    setHiResPhotos={setHiResPhotos}
                     isInitializing={isInitializing}
                     bleDeviceConnected={!!bleDevice?.connected}
                     theme={theme}

--- a/src/screens/Deployments/components/AdvancedSettingsSection.tsx
+++ b/src/screens/Deployments/components/AdvancedSettingsSection.tsx
@@ -30,6 +30,8 @@ interface AdvancedSettingsSectionProps {
     handleSdCardCheck: () => void
     recordJpegOnly: boolean
     setRecordJpegOnly: (val: boolean) => void
+    hiResPhotos: boolean
+    setHiResPhotos: (val: boolean) => void
     isInitializing: boolean
     bleDeviceConnected: boolean
     theme: any
@@ -55,6 +57,8 @@ export const AdvancedSettingsSection: React.FC<AdvancedSettingsSectionProps> = (
     handleSdCardCheck,
     recordJpegOnly,
     setRecordJpegOnly,
+    hiResPhotos,
+    setHiResPhotos,
     isInitializing,
     bleDeviceConnected,
     theme,
@@ -63,6 +67,10 @@ export const AdvancedSettingsSection: React.FC<AdvancedSettingsSectionProps> = (
     onUpdateFirmware
 }) => {
     const [expanded, setExpanded] = useState(false)
+
+    // Hi-res (op32) needs the NN off: blocked whenever the project deploys an AI model
+    const hiResBlocked = !!project?.model_id
+    const hiResEnabled = hiResPhotos && !hiResBlocked
 
     // Battery Render Helpers
 
@@ -105,7 +113,7 @@ export const AdvancedSettingsSection: React.FC<AdvancedSettingsSectionProps> = (
         <Button
             {...props}
             icon="help-circle-outline"
-            onPress={() => onShowHelp('Capture Format', 'Off (default): the camera records each trigger as a high-quality raw BMP plus a JPG, and the website compresses the BMP — better image quality for the current testing phase.\n\nOn: record JPEG only — smaller files, faster uploads, less SD-card use.')}
+            onPress={() => onShowHelp('Capture Format', 'High-resolution photos: one 1216×960 JPEG per trigger instead of 640×480 — about 4× the detail, ~2 s per photo, larger files. Takes effect from the first wake after the device next sleeps. Not available when the project uses an on-device AI model: the model occupies the memory the high-res photo needs, so those deployments always record 640×480.\n\nRecord JPEG only — Off (default): the camera records each trigger as a high-quality raw BMP plus a JPG, and the website compresses the BMP — better image quality for the current testing phase. On: record JPEG only — smaller files, faster uploads, less SD-card use. High-res photos are always JPEG only.')}
         >
             <Text>Help</Text>
         </Button>
@@ -183,12 +191,33 @@ export const AdvancedSettingsSection: React.FC<AdvancedSettingsSectionProps> = (
                     <Card.Content style={styles.content}>
                         <View style={styles.switchRow}>
                             <View style={styles.switchLabel}>
-                                <Text variant="bodyMedium">Record JPEG only</Text>
+                                <Text variant="bodyMedium">High-resolution photos</Text>
                                 <Text style={styles.statusHint}>
-                                    Off (default): record JPG + raw BMP for higher quality. On: JPEG only — smaller, faster.
+                                    {hiResBlocked
+                                        ? 'Unavailable: this project uses an on-device AI model, which needs the standard 640×480 pipeline.'
+                                        : 'One 1216×960 JPEG per trigger (~4× the detail, ~2 s per photo). Starts from the first wake after the device sleeps.'}
                                 </Text>
                             </View>
-                            <Switch value={recordJpegOnly} onValueChange={setRecordJpegOnly} />
+                            <Switch
+                                value={hiResEnabled}
+                                onValueChange={setHiResPhotos}
+                                disabled={hiResBlocked}
+                            />
+                        </View>
+                        <View style={styles.switchRow}>
+                            <View style={styles.switchLabel}>
+                                <Text variant="bodyMedium">Record JPEG only</Text>
+                                <Text style={styles.statusHint}>
+                                    {hiResEnabled
+                                        ? 'High-res photos are always JPEG only.'
+                                        : 'Off (default): record JPG + raw BMP for higher quality. On: JPEG only — smaller, faster.'}
+                                </Text>
+                            </View>
+                            <Switch
+                                value={hiResEnabled || recordJpegOnly}
+                                onValueChange={setRecordJpegOnly}
+                                disabled={hiResEnabled}
+                            />
                         </View>
                     </Card.Content>
                 </Card>

--- a/src/screens/Deployments/hooks/useStartDeployment.ts
+++ b/src/screens/Deployments/hooks/useStartDeployment.ts
@@ -89,6 +89,14 @@ export const useStartDeployment = ({
     // "Record JPEG only" toggle opts out. See bmp-ingestion-analysis.md.
     const [recordJpegOnly, setRecordJpegOnly] = useState(false)
 
+    // Hi-res photos (op32): one 1216x960 JPEG per trigger instead of 640x480.
+    // Requires no on-device AI model (the raw frame occupies the NN arena), so
+    // the toggle is blocked for projects with a model. Written after resetOps
+    // so the factory-reset diff does not clobber it. The firmware picks the
+    // datapath at sensor init, so hi-res starts from the first wake after the
+    // device next sleeps. See firmware _Documentation/hires-capture.md.
+    const [hiResPhotos, setHiResPhotos] = useState(false)
+
     const [submitting, setSubmitting] = useState(false)
     const [project, setProject] = useState<any>(null)
     const [availableProjects, setAvailableProjects] = useState<ProjectWithDetails[]>([])
@@ -303,6 +311,11 @@ export const useStartDeployment = ({
 
         log('[DeploymentDetails] Project changed by user:', projectId)
         setProject(newProject);
+
+        if (newProject.model_id) {
+            // Hi-res requires the NN off — not available for AI-model projects
+            setHiResPhotos(false)
+        }
 
         if (newProject.capture_method_id) {
             const methods = await ReferenceDataService.getCaptureMethods()
@@ -562,19 +575,36 @@ export const useStartDeployment = ({
                 throw configError
             }
 
-            // 7b. Capture format: JPG+BMP by default (quality trial); the advanced
+            // 7b. Capture format.
+            // Hi-res (op32=1): one 1216x960 JPEG per trigger via the CPU pipeline.
+            // Forces JPEG-only single-shot (BMP alternation and multi-shot are
+            // untested on the hi-res path, and single-shot also avoids the
+            // back-to-back delivery-contention caveat in hires-capture.md).
+            // Requires no AI model — guarded in the UI and re-checked here;
+            // resetOps/syncAiModel already erased any stale model when the
+            // project has none.
+            // Otherwise: JPG+BMP by default (quality trial); the advanced
             // "Record JPEG only" toggle disables BMP. TEST_BIT_SAVE_BMP makes the
             // firmware alternate JPG/BMP, so 2 pics/trigger yields one of each.
-            // Non-fatal: on failure the firmware keeps its clean-slate default
-            // (TEST_MODE_BITS=0 = JPEG only). See bmp-ingestion-analysis.md.
+            // Non-fatal: on failure the firmware keeps its clean-slate defaults
+            // (JPEG only, 640x480). See bmp-ingestion-analysis.md.
+            const hiRes = hiResPhotos && !project.model_id
             try {
-                const testModeBits = recordJpegOnly ? 0 : TEST_BIT_SAVE_BMP
-                const numPictures = recordJpegOnly ? 1 : 2
+                const testModeBits = (recordJpegOnly || hiRes) ? 0 : TEST_BIT_SAVE_BMP
+                const numPictures = (recordJpegOnly || hiRes) ? 1 : 2
                 await bleSession?.execute(() => commandRegistry.setop({ index: OP_PARAMETER.TEST_MODE_BITS, value: testModeBits }))
                 await bleSession?.execute(() => commandRegistry.setop({ index: OP_PARAMETER.NUM_PICTURES, value: numPictures }))
-                progress.addLog(`Capture format: ${recordJpegOnly ? 'JPEG only' : 'JPG + BMP'} (${numPictures} pic${numPictures > 1 ? 's' : ''}/trigger)`)
+                if (hiRes) {
+                    await bleSession?.execute(() => commandRegistry.setop({ index: OP_PARAMETER.CAM_RESOLUTION, value: 1 }))
+                    progress.addLog('Capture format: high-res JPEG (1216×960), 1 pic/trigger — starts from the first wake after the device sleeps')
+                } else {
+                    progress.addLog(`Capture format: ${recordJpegOnly ? 'JPEG only' : 'JPG + BMP'} (${numPictures} pic${numPictures > 1 ? 's' : ''}/trigger)`)
+                }
             } catch (formatError) {
                 logWarn('[Deployment] Failed to set capture format (non-fatal):', formatError)
+                if (hiRes) {
+                    progress.addLog('⚠️ Could not enable high-res — the deployment will record 640×480')
+                }
             }
 
             // 7c. One-shot light check: take a single reference photo (every capture
@@ -657,7 +687,7 @@ export const useStartDeployment = ({
             Alert.alert('Error', 'Failed to start deployment: ' + (error as any).message)
             isStartDeploymentInProgress.current = false
         }
-    }, [formState.cameraHeight, formState.notes, bleDevice, bleSession, project, user, deviceId, startConfigure, progress, monitoring, batteryLevel, device?.deviceEui, gpsLocation, locationName, sdCardStatus?.free, sdCardStatus?.total, aiProcessorFailed, initPayload?.deviceFirmwareVersion, initErrors.deviceHealth, deploymentPhotoPaths, recordJpegOnly])
+    }, [formState.cameraHeight, formState.notes, bleDevice, bleSession, project, user, deviceId, startConfigure, progress, monitoring, batteryLevel, device?.deviceEui, gpsLocation, locationName, sdCardStatus?.free, sdCardStatus?.total, aiProcessorFailed, initPayload?.deviceFirmwareVersion, initErrors.deviceHealth, deploymentPhotoPaths, recordJpegOnly, hiResPhotos])
 
     const handleFinishDismiss = useCallback(() => {
         progress.setIsFinishing(false)
@@ -759,6 +789,8 @@ export const useStartDeployment = ({
         handleBatteryCheck, handleSdCardCheck,
         // Capture format (advanced): JPG+BMP default, opt out to JPEG only
         recordJpegOnly, setRecordJpegOnly,
+        // Hi-res photos (advanced): op32 = one 1216x960 JPEG per trigger; needs no AI model
+        hiResPhotos, setHiResPhotos,
         // DFU control
         isDfuInProgress,
     }


### PR DESCRIPTION
## Summary

Adds a user-facing **"High-resolution photos"** toggle to the deployment form (Advanced Settings → Capture Format), letting a deployment record one **1216×960 JPEG** per trigger (firmware op32 = 1) instead of the standard 640×480.

## How it works

- **UI** (`AdvancedSettingsSection.tsx`): new switch next to "Record JPEG only". When the selected project deploys an on-device AI model the switch is disabled with an explanation — hi-res requires the NN off (op14 = 0) because the raw frame occupies the tensor arena. While hi-res is on, the "Record JPEG only" switch shows locked-on (hi-res is always a single JPEG). The card's Help dialog covers both toggles.
- **Deployment pipeline** (`useStartDeployment.ts`): the toggle is applied in the capture-format step (7b), which runs **after** `resetOps`, so the factory-reset diff cannot clobber it. When enabled (and re-guarded against `project.model_id` at submit time) it writes `TEST_MODE_BITS=0`, `NUM_PICTURES=1`, and `CAM_RESOLUTION(32)=1` — single-shot JPEG-only, which also sidesteps the back-to-back delivery-contention caveat documented in the firmware's `hires-capture.md`. Switching to a project with an AI model resets the toggle off.
- **Messaging**: the progress log states the chosen format and that hi-res starts **from the first wake after the device sleeps** (the firmware picks the datapath at sensor init). A failed write stays non-fatal but logs an explicit "⚠️ Could not enable high-res — the deployment will record 640×480".

## What deliberately did not change

- End-deployment: nothing needed — the next deployment's `resetOps` restores op32 = 0, and `FACTORY_DEFAULTS` already includes ops 29–33.
- `verifyConfigDefaults` is unaffected (only used by the firmware-update flow).

## Firmware dependency

op32 support ships with the Seeed_Grove_Vision_AI_Module_V2 hi-res PR stack (#144 → #143 → #140 → #142 → #141 into `dev`). On older firmware the `setop 32 1` write is ignored harmlessly and the deployment records 640×480, so releasing the app first is safe but the toggle is a no-op until devices are updated.

## Testing

- `tsc --noEmit` clean; eslint on the three changed files: 0 errors.
- Pre-commit hook: related unit tests + type-check passed.
- Not yet exercised end-to-end on hardware — needs an app build plus a WW500 to walk the deployment flow and confirm 1216×960 photos after the first sleep/wake cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
