### PR TITLE
fix(ble): survive iOS CoreBluetooth write stalls + fix 0% progress display

### DIFF
--- a/src/ble/protocol/fileTransfer/runFileTransferPipeline.ts
+++ b/src/ble/protocol/fileTransfer/runFileTransferPipeline.ts
@@ -123,6 +123,17 @@ export async function runFileTransferPipeline(
   // expose - slower, but drops become impossible by protocol. Android keeps
   // the tuned without-response fast path.
   const writeWithResponse = Platform.OS === 'ios'
+
+  // iOS: CoreBluetooth stalls the in-flight write for >5 s when it
+  // renegotiates the connection interval (~30 s in, and again later). With the
+  // old 5 s write timeout the app aborted mid-stall while the firmware waited
+  // out its 15 s session-inactivity hold (bench 19 Jul 2026: died at packet
+  // ~197/2125 with "BleManager.write function timed out" while the device sat
+  // healthy). 12 s rides out observed stalls and stays under the firmware's
+  // 15 s budget, so both ends outlast the stall together. ATT ordering on the
+  // with-response path makes duplicate delivery impossible when the stalled
+  // write eventually flushes. Android keeps the 5 s default.
+  const WRITE_TIMEOUT_MS = Platform.OS === 'ios' ? 12000 : 5000
   const transferId = generateTransferId()
   const startTime = Date.now()
 
@@ -390,7 +401,7 @@ export async function runFileTransferPipeline(
         const fileStartT0 = Date.now()
         const startAckPromise = prepareAckWait({ phase: 'start' }, FILE_START_ACK_TIMEOUT_MS)
         if (isDisconnected) throw new FileTransferError('DISCONNECTED', 'Device disconnected before FILE_START')
-        await writeBinaryToDevice(peripheral, startPacket, writeWithResponse)
+        await writeBinaryToDevice(peripheral, startPacket, writeWithResponse, WRITE_TIMEOUT_MS)
         log(`[FileTransfer] FILE_START sent: ${filename} (${data.length} bytes) [attempt ${sessionAttempt + 1}]`)
 
         await startAckPromise
@@ -433,7 +444,7 @@ export async function runFileTransferPipeline(
             currentAckStartTime = Date.now()
             currentAckPromise = prepareAckWait({ phase: 'data', packetNum: pkt.wireNum })
             if (isDisconnected) throw new FileTransferError('DISCONNECTED', 'Device disconnected before write')
-            await writeBinaryToDevice(peripheral, pkt.packet, writeWithResponse)
+            await writeBinaryToDevice(peripheral, pkt.packet, writeWithResponse, WRITE_TIMEOUT_MS)
           }
 
           while (i < preBuiltPackets.length) {
@@ -453,7 +464,7 @@ export async function runFileTransferPipeline(
                 wirePacketNum = next.wireNum
                 currentAckStartTime = Date.now()
                 currentAckPromise = prepareAckWait({ phase: 'data', packetNum: next.wireNum })
-                await writeBinaryToDevice(peripheral, next.packet, writeWithResponse)
+                await writeBinaryToDevice(peripheral, next.packet, writeWithResponse, WRITE_TIMEOUT_MS)
               }
 
               // ── ACCOUNTING (next write is already in BLE stack) ────
@@ -486,7 +497,7 @@ export async function runFileTransferPipeline(
               wirePacketNum = pkt.wireNum
               currentAckStartTime = Date.now()
               currentAckPromise = prepareAckWait({ phase: 'data', packetNum: pkt.wireNum })
-              await writeBinaryToDevice(peripheral, pkt.packet, writeWithResponse)
+              await writeBinaryToDevice(peripheral, pkt.packet, writeWithResponse, WRITE_TIMEOUT_MS)
             }
           }
         } else {
@@ -567,8 +578,19 @@ export async function runFileTransferPipeline(
               // responding"). The real throughput limiter was JS-thread congestion
               // from per-ack Engineer-Console logging, fixed in useBleListeners.
               while (nextToSend < total && (nextToSend - (highestAckedIndex + 1)) < windowSize) {
-                await writeBinaryToDevice(peripheral, preBuiltPackets[nextToSend].packet, writeWithResponse)
+                await writeBinaryToDevice(peripheral, preBuiltPackets[nextToSend].packet, writeWithResponse, WRITE_TIMEOUT_MS)
                 nextToSend++
+                // On iOS a with-response write takes longer than the ack
+                // round-trip, so credit is replenished as fast as it is spent
+                // and this fill loop can span the ENTIRE transfer - emit
+                // progress here too or the UI sits at 0% (throttled, so this
+                // costs nothing on Android's fast path).
+                if (highestAckedIndex >= 0) {
+                  bytesSent = preBuiltPackets[highestAckedIndex].chunkEnd
+                  packetsAcked = highestAckedIndex + 1
+                  wirePacketNum = preBuiltPackets[highestAckedIndex].wireNum
+                  throttledEmitProgress(highestAckedIndex)
+                }
               }
 
               // Progress (based on cumulative acks)
@@ -608,7 +630,7 @@ export async function runFileTransferPipeline(
         const fileEndT0 = Date.now()
         const endAckPromise = prepareAckWait({ phase: 'end' })
         if (isDisconnected) throw new FileTransferError('DISCONNECTED', 'Device disconnected before FILE_END')
-        await writeBinaryToDevice(peripheral, endPacket, writeWithResponse)
+        await writeBinaryToDevice(peripheral, endPacket, writeWithResponse, WRITE_TIMEOUT_MS)
         log(`[FileTransfer] FILE_END sent: CRC=0x${crc.toString(16).toUpperCase().padStart(4, '0')}`)
 
         await endAckPromise
@@ -642,7 +664,12 @@ export async function runFileTransferPipeline(
         const isFileTransferError = sessionErr instanceof FileTransferError
         const hasDeviceErrorReason = sessionErr?.reason === 'DEVICE_ERROR'
         const hasErrorCode7 = sessionErr?.errorCode === 7
-        const isRecoverable = isFileTransferError && hasDeviceErrorReason && hasErrorCode7
+        // A write timeout means CoreBluetooth stalled past WRITE_TIMEOUT_MS
+        // (seen on iOS interval renegotiations). The device parks the session
+        // and DPDs after its 15 s hold; a fresh FILE_START wakes it, so a
+        // full-session retry is safe and usually succeeds.
+        const isWriteTimeout = /timed out/i.test(String(sessionErr?.message ?? ''))
+        const isRecoverable = (isFileTransferError && hasDeviceErrorReason && hasErrorCode7) || isWriteTimeout
 
         log(`[FileTransfer] Session error caught: instanceof=${isFileTransferError}, reason=${sessionErr?.reason}, errorCode=${sessionErr?.errorCode} (type=${typeof sessionErr?.errorCode}), isRecoverable=${isRecoverable}`)
 

--- a/src/ble/transport.ts
+++ b/src/ble/transport.ts
@@ -75,11 +75,18 @@ export const writeToDevice: WriteFunction = async (peripheral, data) => {
  *                      Use for FILE_START and FILE_END. If false, uses
  *                      write-without-response (fast, ACK-confirmed by protocol).
  *                      Use for FILE_DATA.
+ * @param timeoutMs     Per-write timeout. iOS CoreBluetooth can stall a
+ *                      write-with-response for well over 5 s during connection
+ *                      parameter renegotiation — callers on that path must pass
+ *                      a budget below the firmware's 15 s session-inactivity
+ *                      hold but above the observed stalls (see
+ *                      runFileTransferPipeline WRITE_TIMEOUT_MS).
  */
 export const writeBinaryToDevice = async (
 	peripheral: ExtendedPeripheral,
 	data: Uint8Array,
 	withResponse: boolean = false,
+	timeoutMs: number = 5000,
 ): Promise<void> => {
 	if (!peripheral.connected) {
 		throw new Error('Device disconnected')
@@ -95,7 +102,7 @@ export const writeBinaryToDevice = async (
 
 	const label = withResponse ? 'BleManager.write' : 'BleManager.writeWithoutResponse'
 
-	await invokeWithTimeout(writeFn, label, 5000)
+	await invokeWithTimeout(writeFn, label, timeoutMs)
 }
 
 


### PR DESCRIPTION
## Summary

Companion to Seeed PR #146 — the app half of the iOS large-transfer fix, from tonight's bench session (WW500 C02, firmware with the 15 s session-inactivity hold, app 0.0.60 baseline).

**Bench result that motivated this:** with the firmware fix in place, LARGE.BIN ran to packet ~197/2125 (double the old death point, straight through the first ~30 s renegotiation) and then died with `BleManager.write function timed out` — a later CoreBluetooth stall exceeded the app's hard-coded **5 s** write timeout, so the app aborted **while the device sat healthy, waiting out its 15 s hold** (`Inactive for 15000ms` fired 15 s later, exactly as designed). The patience mismatch had simply moved from firmware to app.

## Changes

1. **`writeBinaryToDevice` gains a `timeoutMs` parameter** (default unchanged at 5 s for all other callers).
2. **Pipeline write timeout: 12 s on iOS** (5 s on Android, unchanged) — above observed renegotiation stalls, below the firmware's 15 s budget, so both ends outlast a stall together. ATT ordering on the with-response path makes duplicate delivery impossible when a stalled write eventually flushes.
3. **Write timeouts are now session-recoverable** — a >12 s stall tears the session down, but the existing full-session retry engages (fresh FILE_START re-wakes the device from DPD, which tonight's captures prove works). Previously the error fell through as fatal and the app disconnected.
4. **Progress display fixed (the "0% forever" bug)**: on iOS, a with-response write takes longer than the ack round-trip, so the window-fill inner loop never drains and the outer loop's progress block never ran — transfers showed `0% / Starting transfer…` while hundreds of packets flowed (console-verified). Progress is now also emitted (throttled) inside the fill loop; costs nothing on Android's fast path.

## Validation

`tsc --noEmit` clean; ESLint clean on both files. On-device retest needs an iOS build from this branch/dev — acceptance: LARGE.BIN completes with CRC, UI shows live progress, and any mid-transfer stall recovers instead of erroring.
