### PR TITLE
fix(ble): iOS command writes use write-with-response (completes #213)

### DIFF
--- a/src/ble/__tests__/transport.test.ts
+++ b/src/ble/__tests__/transport.test.ts
@@ -12,6 +12,7 @@ import {
 
 // Mock dependencies
 jest.mock("react-native-ble-manager", () => ({
+	write: jest.fn(),
 	writeWithoutResponse: jest.fn(),
 }))
 
@@ -43,21 +44,43 @@ describe("src/ble/transport", () => {
 			expect(BleManager.writeWithoutResponse).not.toHaveBeenCalled()
 		})
 
-		it("should write data to device", async () => {
+		it("should write data with response on iOS (jest preset default)", async () => {
+			// CoreBluetooth silently drops .withoutResponse writes when its queue
+			// is full, so iOS must use write-with-response (same rationale as the
+			// file-transfer path).
 			await writeToDevice(mockPeripheral, "test-data")
 
-			expect(BleManager.writeWithoutResponse).toHaveBeenCalledWith(
+			expect(BleManager.write).toHaveBeenCalledWith(
 				"device-123",
 				"service-uuid",
 				"write-uuid",
 				expect.any(Array), // Byte array
 				512
 			)
+			expect(BleManager.writeWithoutResponse).not.toHaveBeenCalled()
+		})
 
+		it("should keep the without-response fast path on Android", async () => {
+			const { Platform } = jest.requireActual<typeof import("react-native")>("react-native")
+			const originalOS = Platform.OS
+			try {
+				Object.defineProperty(Platform, "OS", { value: "android", configurable: true })
+				await writeToDevice(mockPeripheral, "test-data")
+				expect(BleManager.writeWithoutResponse).toHaveBeenCalledWith(
+					"device-123",
+					"service-uuid",
+					"write-uuid",
+					expect.any(Array),
+					512
+				)
+				expect(BleManager.write).not.toHaveBeenCalled()
+			} finally {
+				Object.defineProperty(Platform, "OS", { value: originalOS, configurable: true })
+			}
 		})
 
 		it("should handle write errors", async () => {
-			(BleManager.writeWithoutResponse as jest.Mock).mockRejectedValue(new Error("Write failed"))
+			(BleManager.write as jest.Mock).mockRejectedValue(new Error("Write failed"))
 			await expect(writeToDevice(mockPeripheral, "test-data")).rejects.toThrow("Write failed")
 		})
 	})

--- a/src/ble/__tests__/transport.test.ts
+++ b/src/ble/__tests__/transport.test.ts
@@ -9,6 +9,7 @@ import {
 	BLE_CHARACTERISTIC_WRITE_UUID,
 	BLE_CHARACTERISTIC_READ_UUID,
 } from "../../utils/constants"
+import { Platform } from "react-native"
 
 // Mock dependencies
 jest.mock("react-native-ble-manager", () => ({
@@ -44,11 +45,17 @@ describe("src/ble/transport", () => {
 			expect(BleManager.writeWithoutResponse).not.toHaveBeenCalled()
 		})
 
-		it("should write data with response on iOS (jest preset default)", async () => {
+		it("should write data with response on iOS", async () => {
 			// CoreBluetooth silently drops .withoutResponse writes when its queue
 			// is full, so iOS must use write-with-response (same rationale as the
 			// file-transfer path).
-			await writeToDevice(mockPeripheral, "test-data")
+			const originalOS = Platform.OS
+			Object.defineProperty(Platform, "OS", { value: "ios", configurable: true })
+			try {
+				await writeToDevice(mockPeripheral, "test-data")
+			} finally {
+				Object.defineProperty(Platform, "OS", { value: originalOS, configurable: true })
+			}
 
 			expect(BleManager.write).toHaveBeenCalledWith(
 				"device-123",
@@ -61,7 +68,6 @@ describe("src/ble/transport", () => {
 		})
 
 		it("should keep the without-response fast path on Android", async () => {
-			const { Platform } = jest.requireActual<typeof import("react-native")>("react-native")
 			const originalOS = Platform.OS
 			try {
 				Object.defineProperty(Platform, "OS", { value: "android", configurable: true })

--- a/src/ble/transport.ts
+++ b/src/ble/transport.ts
@@ -45,12 +45,16 @@ export const writeToDevice: WriteFunction = async (peripheral, data) => {
 			const iosWithResponse = Platform.OS === "ios"
 			const serviceUuid = peripheral.services?.serviceCharacteristic || BLE_SERVICE_UUID
 			const writeUuid = peripheral.services?.writeCharacteristic || BLE_CHARACTERISTIC_WRITE_UUID
+			// iOS write-with-response can stall >5 s during connection parameter
+			// renegotiation (see writeBinaryToDevice docs) - budget 12 s there,
+			// matching the file-transfer pipeline's write timeout.
+			const timeoutMs = iosWithResponse ? 12000 : 5000
 			await invokeWithTimeout(
 				() => iosWithResponse
 					? BleManager.write(peripheral.id, serviceUuid, writeUuid, byteArray, 512)
 					: BleManager.writeWithoutResponse(peripheral.id, serviceUuid, writeUuid, byteArray, 512),
 				iosWithResponse ? "BleManager.write" : "BleManager.writeWithoutResponse",
-				5000 // 5s timeout
+				timeoutMs
 			)
 
 			log(

--- a/src/ble/transport.ts
+++ b/src/ble/transport.ts
@@ -1,4 +1,5 @@
 import BleManager from "react-native-ble-manager"
+import { Platform } from "react-native"
 import { Buffer } from "buffer"
 import dayjs from "dayjs"
 import { log } from "../utils/logger"
@@ -33,16 +34,22 @@ export const writeToDevice: WriteFunction = async (peripheral, data) => {
 			// log('DEBUG: byteArray content:', byteArray)
 			log(`TX Hex: ${logHex}`)
 
+			// iOS: write-WITH-response, same rationale as the file-transfer path
+			// (#213): CoreBluetooth silently discards .withoutResponse writes when
+			// its queue is full - once iOS relaxes the connection interval (~30s
+			// in), commands and session keepalives vanish with no error, the
+			// device sees silence, and its idle policy drops the link ("RX:
+			// Disconnecting" mid-console-session). ATT write-with-response makes
+			// drops impossible by protocol; for CLI-sized packets the throughput
+			// cost is irrelevant. Android keeps the without-response fast path.
+			const iosWithResponse = Platform.OS === "ios"
+			const serviceUuid = peripheral.services?.serviceCharacteristic || BLE_SERVICE_UUID
+			const writeUuid = peripheral.services?.writeCharacteristic || BLE_CHARACTERISTIC_WRITE_UUID
 			await invokeWithTimeout(
-				() => BleManager.writeWithoutResponse(
-					peripheral.id,
-					peripheral.services?.serviceCharacteristic || BLE_SERVICE_UUID,
-					peripheral.services?.writeCharacteristic ||
-					BLE_CHARACTERISTIC_WRITE_UUID,
-					byteArray,
-					512 // Explicitly allow larger packets
-				),
-				"BleManager.writeWithoutResponse",
+				() => iosWithResponse
+					? BleManager.write(peripheral.id, serviceUuid, writeUuid, byteArray, 512)
+					: BleManager.writeWithoutResponse(peripheral.id, serviceUuid, writeUuid, byteArray, 512),
+				iosWithResponse ? "BleManager.write" : "BleManager.writeWithoutResponse",
 				5000 // 5s timeout
 			)
 


### PR DESCRIPTION
## Summary
#213 fixed the iOS silent-write-drop bug for **file transfers** only. The plain command path (`writeToDevice` in `src/ble/transport.ts`) still used `writeWithoutResponse` unconditionally — CLI commands and session keepalives were exposed to the same CoreBluetooth behaviour: once iOS relaxes the connection interval (~30 s in), queued-full writes are discarded with no error.

**Observed on bench (iOS, 0.0.60 preview):** Engineer Console session dies moments after `AI ver` — the device sees no traffic, its idle policy announces `RX: Disconnecting`, and the link drops.

## Change
`writeToDevice` selects `BleManager.write` (with response) on iOS, keeping Android's without-response fast path — same shape and rationale as #213. Throughput is irrelevant for CLI-sized packets. Unit tests now cover both platform paths.

## Bench retest ask
iOS Engineer Console: connect, send `AI ver`, idle 2–3 minutes, send again — the session should survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)