### PR TITLE
fix(firmware): show BLE transfer progress during Himax update

### DIFF
--- a/src/screens/Devices/FirmwareUpdateScreen.tsx
+++ b/src/screens/Devices/FirmwareUpdateScreen.tsx
@@ -524,7 +524,7 @@ export const FirmwareUpdateScreen = () => {
                         is already beyond 'transferring' for good. The hook clears
                         the state when a transfer finishes, so presence == in flight
                         (or failed, which the card renders). */}
-                    {fileTransferProgress && (
+                    {fileTransferProgress ? (
                         <View style={styles.marginTop12}>
                             <FileTransferProgressCard
                                 title="Transferring to Device"
@@ -540,7 +540,7 @@ export const FirmwareUpdateScreen = () => {
                                 isComplete={fileTransferProgress.phase === 'complete'}
                             />
                         </View>
-                    )}
+                    ) : null}
 
                     {/* Overall Progress bar fallback for non-transfer phases */}
                     {(isUpdating || isComplete) && phase !== 'downloading' && phase !== 'transferring' && (

--- a/src/screens/Devices/FirmwareUpdateScreen.tsx
+++ b/src/screens/Devices/FirmwareUpdateScreen.tsx
@@ -516,7 +516,15 @@ export const FirmwareUpdateScreen = () => {
                         </View>
                     )}
 
-                    {phase === 'transferring' && fileTransferProgress && (
+                    {/* Keyed to the transfer's own lifecycle, NOT the update phase
+                        machine: a device 'Wake' line used to leapfrog the phase past
+                        'transferring' (forward-only ordering), hiding this card for
+                        the whole multi-minute transfer. It also reappears for the
+                        second image of a dual-camera update, where the phase machine
+                        is already beyond 'transferring' for good. The hook clears
+                        the state when a transfer finishes, so presence == in flight
+                        (or failed, which the card renders). */}
+                    {fileTransferProgress && (
                         <View style={styles.marginTop12}>
                             <FileTransferProgressCard
                                 title="Transferring to Device"

--- a/src/screens/Devices/hooks/useFirmwareUpdate.ts
+++ b/src/screens/Devices/hooks/useFirmwareUpdate.ts
@@ -472,7 +472,16 @@ export function useFirmwareUpdate({ target, device }: UseFirmwareUpdateOptions) 
             const line: string = event.line
 
             if (line.includes('Wake') && !line.includes('Wakeup_event')) {
-                advancePhase('waking')
+                // The AI processor emits 'Wake <utc>' EVERY time it wakes -
+                // including when woken for the SD-card transfer. advancePhase is
+                // forward-only and 'waking' sits after 'transferring', so an early
+                // Wake used to leapfrog the phase and block
+                // advancePhase('transferring'), hiding transfer progress for the
+                // whole upload. Only the wake following the flash command
+                // ('sending') is the one this phase describes.
+                if (phaseRef.current === 'sending') {
+                    advancePhase('waking')
+                }
             } else if (line.includes('erase_firmware_slot') || line.includes('Erasing firmware slot') || line.includes('erased OK')) {
                 // Current firmware: "erase_firmware_slot: slot N ..." / "... erased OK".
                 // Legacy strings kept for backward compatibility with older HX6538 builds.
@@ -664,6 +673,9 @@ export function useFirmwareUpdate({ target, device }: UseFirmwareUpdateOptions) 
 
             // 2. Transfer firmware to SD card
             advancePhase('transferring')
+            // Clear the previous pass's progress so the transfer card starts
+            // fresh for image 2 of a dual-camera update
+            if (!unmountedRef.current) setFileTransferProgress(null)
             appendLog(`${passLabel}Transferring firmware to device SD card...`)
             const configBytes = await FirmwareService.readFirmwareAsBytes(localUri)
 
@@ -686,6 +698,9 @@ export function useFirmwareUpdate({ target, device }: UseFirmwareUpdateOptions) 
                 } else {
                     appendLog(`${passLabel}Transfer complete.`)
                 }
+                // Transfer done - drop the progress card (presence == in flight;
+                // on failure the pipeline throws and the failed card stays up)
+                if (!unmountedRef.current) setFileTransferProgress(null)
             } else {
                 throw new Error('Failed to read firmware bytes')
             }


### PR DESCRIPTION
## Symptom (bench, Test 1 firmware-update pass)
During the AI-processor firmware update the multi-minute BLE transfer runs blind — status stuck on **"[Image 1 of 2] AI processor waking up…"** with no percentage, speed, or ETA, even though the log says "Transferring firmware to device SD card…".

## Root cause
The progress plumbing already exists end-to-end (`runFileTransferPipeline onProgress` → `fileTransferProgress` → `FileTransferProgressCard`), but the card was gated on `phase === 'transferring'` — and the phase machine never reaches it: the AI processor emits `Wake <utc>` when woken **for the transfer**, the UART listener advanced the phase to `'waking'` on any Wake line, and `advancePhase` is forward-only with `'waking'` ordered **after** `'transferring'`, so `advancePhase('transferring')` was silently blocked. Image 2 of a dual-camera update could never show progress either — the machine is legitimately past `'transferring'` by then.

## Changes
- `Wake` lines only advance the phase machine while in `'sending'` — the post-flash-command wake that phase actually describes.
- The transfer card renders whenever transfer progress state is present (cleared at each pass's start and on completion), decoupling it from the phase machine — visible for both images, failed state included.
- Note: `FileTransferProgress.phase` has no `'complete'` member, so the previous `isComplete` comparison was dead code; presence-based gating avoids it.

## Bench retest ask
Dual-camera Himax update: both image transfers show live percentage / speed / ETA; "waking up" appears only after the flash command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)