### PR TITLE
fix(firmware): keep screen awake for the whole update flow

### DIFF
--- a/src/screens/Devices/hooks/useFirmwareUpdate.ts
+++ b/src/screens/Devices/hooks/useFirmwareUpdate.ts
@@ -9,6 +9,7 @@ import { DfuService } from '../../../services/DfuService'
 import FirmwareService, { DownloadState, DownloadProgressData } from '../../../services/FirmwareService'
 import ReferenceDataService from '../../../services/ReferenceDataService'
 import Firmware from '../../../database/models/Firmware'
+import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake'
 import { runFileTransferPipeline } from '../../../ble/protocol/fileTransfer'
 import { FileTransferProgress } from '../../../ble/protocol/fileTransfer/fileTransferTypes'
 import { verifyConfigDefaults } from '../../../ble/workflows/configVerification'
@@ -23,6 +24,10 @@ import { convertBleToSemanticVersion } from '../../../utils/versionUtils'
 // ────────────────────────────────────────────────────────────────────
 
 export type FirmwareTarget = 'ble' | 'himax'
+
+// Tag for expo-keep-awake so this hook's activation cannot clobber the
+// file-transfer pipeline's own per-transfer tags
+const KEEP_AWAKE_TAG = 'firmware-update'
 
 export type UpdatePhase =
     | 'idle'
@@ -285,6 +290,19 @@ export function useFirmwareUpdate({ target, device }: UseFirmwareUpdateOptions) 
     const [downloadProgress, setDownloadProgress] = useState<DownloadProgressData | null>(null)
     
     const abortControllerRef = useRef<AbortController | null>(null)
+
+    // Keep the screen awake for the WHOLE update, not just the file transfer
+    // (runFileTransferPipeline holds its own per-transfer tag). The Himax
+    // flash phase (5-10 min of waiting) and the BLE DFU had no coverage: the
+    // screen sleeping backgrounds the app, iOS throttles/park the BLE link,
+    // and the session dies mid-update.
+    useEffect(() => {
+        if (!isUpdating) return
+        activateKeepAwakeAsync(KEEP_AWAKE_TAG).catch(() => { /* best effort */ })
+        return () => {
+            Promise.resolve().then(() => deactivateKeepAwake(KEEP_AWAKE_TAG)).catch(() => { /* best effort */ })
+        }
+    }, [isUpdating])
 
     // Pre-flight
     const [batteryLevel, setBatteryLevel] = useState<number | null>(null)


### PR DESCRIPTION
## Context
Bench iOS trace (21 Jul, 512KB transfer): iOS progressively walked the connection interval out (48ms → 378ms → ~2s between packets) until the link died on a supervision timeout at ~50%. Screen sleep/backgrounding is a major driver of that throttling. The device-side half of the fix is ww-hardware#30 (defend fast conn params); this is the app-side half.

## Change
`runFileTransferPipeline` already activates keep-awake per transfer (#218), but the **Himax flash phase** (5–10 min of waiting for the completion line) and the **BLE DFU path** had no coverage. A hook-level `firmware-update` tag in `useFirmwareUpdate` now spans the whole update (`isUpdating`), both targets, released on complete/failed/unmount — tagged so it can't clobber the pipeline's per-transfer tags.

## Retest
iOS firmware update with the phone untouched: screen should stay on for the full flow; pair with ww-hardware#30 for the throughput half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)