### PR TITLE
fix(deployment): stop factory reset erasing the synced AI model

### DIFF
--- a/src/ble/workflows/deploymentPipeline.ts
+++ b/src/ble/workflows/deploymentPipeline.ts
@@ -124,8 +124,13 @@ export async function syncAiModel(
             }
             const { firmwareModelId: numericId, versionNumber: numericVer } = firmwareIds
             const { modelExt: tflExt, labelsExt } = AiModelService.getModelFileExtensions(targetModel)
-            const tflFilename = `${numericId}V${numericVer}.${tflExt}`
-            const labelsFilename = `${numericId}V${numericVer}.${labelsExt}`
+            // Uppercase: both the app's transfer validator and the firmware's
+            // fileRx require uppercase 8.3 names - a lowercase extension
+            // ('1V1.tfl') failed validation BEFORE any transfer, so the model
+            // never reached the SD card (bench 21 Jul). FAT is case-insensitive,
+            // so loadmodel finds the file either way.
+            const tflFilename = `${numericId}V${numericVer}.${tflExt}`.toUpperCase()
+            const labelsFilename = `${numericId}V${numericVer}.${labelsExt}`.toUpperCase()
 
             // 3. Check current OPs to see if model is already loaded
             const ops = currentOps || await session.execute(() => commandRegistry.getops())

--- a/src/ble/workflows/deploymentPipeline.ts
+++ b/src/ble/workflows/deploymentPipeline.ts
@@ -61,6 +61,9 @@ export async function resetOps(
         await executeResetToDefaults(session, {
             currentOps,
             skipIdentityReset: true,
+            // syncAiModel owns model state in the deployment pipeline - the
+            // reset must not erase the model it just loaded (op14/15 + flash)
+            preserveModel: true,
             onProgress: (step) => {
                 log(`[ResetOps] ${step}`)
             }
@@ -213,7 +216,7 @@ export async function syncAiModel(
 
         } catch (e) {
             logWarn('Failed to update AI model:', e)
-            addLog('AI model update failed, continuing...')
+            addLog('⚠️ AI model update FAILED — the deployment will record but not classify. See device log.')
         }
     } else if (eraseStaleModels) {
         // No AI model assigned — check if device has a stale model loaded

--- a/src/ble/workflows/deploymentPipeline.ts
+++ b/src/ble/workflows/deploymentPipeline.ts
@@ -182,10 +182,21 @@ export async function syncAiModel(
                     if (!modelBytes) {
                         throw new Error(`Failed to read model bytes from ${localFiles.modelUri}`)
                     }
+                    // Live feedback: a model is minutes of BLE transfer, and the
+                    // old mapping moved the overall bar 4% total - invisible.
+                    // The step line carries percentage + KB (throttled to whole
+                    // percents; onProgress fires per packet).
+                    let lastPct = -1
                     await runFileTransferPipeline(device, {
                         filename: tflFilename,
                         data: modelBytes,
-                        onProgress: (p) => setProgress(0.14 + (p.percentage / 100) * 0.04)
+                        onProgress: (p) => {
+                            setProgress(0.14 + (p.percentage / 100) * 0.04)
+                            if (p.percentage !== lastPct) {
+                                lastPct = p.percentage
+                                setStep(`Transferring model… ${p.percentage}% (${Math.round(p.bytesSent / 1024)}/${Math.round(p.totalBytes / 1024)} KB)`)
+                            }
+                        }
                     })
                     addLog(`✅ ${tflFilename} transferred`)
                 }
@@ -200,7 +211,7 @@ export async function syncAiModel(
                     await runFileTransferPipeline(device, {
                         filename: labelsFilename,
                         data: labelsBytes,
-                        onProgress: () => {}
+                        onProgress: (p) => setStep(`Transferring labels… ${p.percentage}%`)
                     })
                     addLog(`✅ ${labelsFilename} transferred`)
                 }

--- a/src/ble/workflows/resetToDefaults.ts
+++ b/src/ble/workflows/resetToDefaults.ts
@@ -8,6 +8,15 @@ export interface ResetToDefaultsOptions {
     isCancelled?: () => boolean
     currentOps?: string[] | null
     skipIdentityReset?: boolean
+    /**
+     * Keep the loaded AI model: skip erasemodel AND leave op14/op15
+     * (MODEL_PROJECT/MODEL_VERSION) untouched. Deployment flows must set
+     * this - syncAiModel is the model authority there, and the old
+     * behaviour erased the freshly-synced model AFTER the sync step
+     * (pipeline order: syncAiModel -> ... -> resetOps), so every model
+     * deployment started modelless: MD wakes fired but the NN never ran.
+     */
+    preserveModel?: boolean
 }
 
 /**
@@ -51,6 +60,12 @@ export async function executeResetToDefaults(
             if (parseInt(currentOps[index], 10) > 0) continue
         }
 
+        // 1b) Preserve the model binding when the caller owns model state
+        if (options?.preserveModel &&
+            (index === OP_PARAMETER.MODEL_PROJECT || index === OP_PARAMETER.MODEL_VERSION)) {
+            continue
+        }
+
         // 2) Do not reset tracking parameters and counters
         if (
             index === OP_PARAMETER.NUM_NN_ANALYSES ||
@@ -75,8 +90,9 @@ export async function executeResetToDefaults(
 
     log(`[ResetDefaults] ${opsToWrite.length} OPs need writing, model loaded: ${hasModel}`)
 
-    // Step 3: Erase AI model if one is loaded
-    if (hasModel) {
+    // Step 3: Erase AI model if one is loaded (never in deployment flows -
+    // erasing here destroyed the flash cache the sync step had just ensured)
+    if (hasModel && !options?.preserveModel) {
         onProgress?.('Erasing AI model...', 0.2)
         log('[ResetDefaults] Erasing AI model...')
         try {

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -12,7 +12,7 @@
 import { appSchema, tableSchema } from '@nozbe/watermelondb'
 
 export default appSchema({
-    version: 399,
+    version: 400,
     tables: [
         tableSchema({
             name: 'account_deletion_requests',

--- a/src/hooks/useDevicePreDeploymentChecks.ts
+++ b/src/hooks/useDevicePreDeploymentChecks.ts
@@ -170,6 +170,9 @@ export const useDevicePreDeploymentChecks = () => {
                 onProgress('Aligning device parameters...')
                 await executeResetToDefaults(session, {
                     skipIdentityReset: true,
+                    // Pre-deployment alignment must not wipe the model - the
+                    // deployment's syncAiModel step owns model state
+                    preserveModel: true,
                     onProgress: (step) => {
                         log(`[Pre-Deployment:Reset] ${step}`)
                     }

--- a/src/screens/Deployments/hooks/useStartDeployment.ts
+++ b/src/screens/Deployments/hooks/useStartDeployment.ts
@@ -675,8 +675,12 @@ export const useStartDeployment = ({
             // after syncAiModel loaded it).
             try {
                 const finalOps = await bleSession?.execute(commandRegistry.getops)
-                const modelId = parseInt(finalOps?.[OP_PARAMETER.MODEL_PROJECT] ?? '0', 10) || 0
-                const modelVer = parseInt(finalOps?.[OP_PARAMETER.MODEL_VERSION] ?? '0', 10) || 0
+                if (!finalOps) {
+                    // A failed read must NOT masquerade as 'NO MODEL LOADED'
+                    throw new Error('No operational parameters returned from device')
+                }
+                const modelId = parseInt(finalOps[OP_PARAMETER.MODEL_PROJECT] ?? '0', 10) || 0
+                const modelVer = parseInt(finalOps[OP_PARAMETER.MODEL_VERSION] ?? '0', 10) || 0
                 if (project.model_id && modelId !== 0) {
                     progress.addLog(`🧠 AI model active on device (ID ${modelId} v${modelVer})`)
                 } else if (project.model_id && modelId === 0) {

--- a/src/screens/Deployments/hooks/useStartDeployment.ts
+++ b/src/screens/Deployments/hooks/useStartDeployment.ts
@@ -668,6 +668,26 @@ export const useStartDeployment = ({
                 logWarn('[Deployment] Light check failed (non-fatal):', lightError)
             }
 
+            // 7d. Model verification: read back op14/15 and say LOUDLY whether
+            // the NN is actually armed for this deployment. Guards the whole
+            // class of silent-modelless starts (bench 21 Jul: sessions logged
+            // 'motion detected' forever because resetOps had erased the model
+            // after syncAiModel loaded it).
+            try {
+                const finalOps = await bleSession?.execute(commandRegistry.getops)
+                const modelId = parseInt(finalOps?.[OP_PARAMETER.MODEL_PROJECT] ?? '0', 10) || 0
+                const modelVer = parseInt(finalOps?.[OP_PARAMETER.MODEL_VERSION] ?? '0', 10) || 0
+                if (project.model_id && modelId !== 0) {
+                    progress.addLog(`🧠 AI model active on device (ID ${modelId} v${modelVer})`)
+                } else if (project.model_id && modelId === 0) {
+                    progress.addLog('⚠️ NO MODEL LOADED — the camera will capture on motion but nothing will be classified. Re-run the deployment or check the model sync log above.')
+                } else {
+                    progress.addLog('No on-device AI model for this project (motion-capture only)')
+                }
+            } catch (verifyError) {
+                logWarn('[Deployment] Model verification read failed (non-fatal):', verifyError)
+            }
+
             progress.setFinishStep('Complete')
             progress.setFinishProgress(1.0)
             progress.setIsSuccess(true)


### PR DESCRIPTION
## Bug (bench, 21 Jul — person-detection deployment on a fresh SD)
Live monitor showed only "motion detected", never a classification. Root cause is pipeline order: **syncAiModel runs first, resetOps runs later** — and `executeResetToDefaults` both sent `erasemodel` (destroying the flash-cached model the sync had just ensured) and diff-wrote `MODEL_PROJECT`/`MODEL_VERSION` (op14/15) to factory 0. The silent pre-deployment reset on screen mount did the same even earlier. Net: **every model deployment started modelless.**

## Changes
- `resetToDefaults`: new `preserveModel` option — skips `erasemodel` and leaves op14/15 untouched. Set by the deployment pipeline reset **and** the pre-deployment alignment reset; the Engineer Console's manual factory reset keeps today's full wipe.
- **Post-configure verification** (new step 7d): reads op14/15 back and logs loudly in the finish dialog — `🧠 AI model active (ID N vM)` / `⚠️ NO MODEL LOADED — will capture but not classify` / `motion-capture only`.
- `syncAiModel`'s catch-all failure message now says plainly the deployment will record but not classify.

## Retest
Start a monitoring session on the person-detection project with any SD card: the finish log must end with `🧠 AI model active…`, and a walk-past should produce a classified detection. A fresh SD card + previously-loaded model is also fine (model loads from flash; op14/15 legitimately claim it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)