### PR TITLE
fix(firmware): visible tick controls on iOS

### DIFF
--- a/src/screens/Devices/FirmwareUpdateScreen.tsx
+++ b/src/screens/Devices/FirmwareUpdateScreen.tsx
@@ -363,7 +363,7 @@ export const FirmwareUpdateScreen = () => {
                                 : '⚠️ Battery is below 30%. Updating with low battery risks bricking the device. Charge before continuing.'}
                         </WWText>
                         <View style={styles.overrideRow}>
-                            <Checkbox
+                            <Checkbox.Android
                                 status={externalPowerConfirmed ? 'checked' : 'unchecked'}
                                 onPress={() => setExternalPowerConfirmed(v => !v)}
                                 color="#FFF3E0"
@@ -458,7 +458,7 @@ export const FirmwareUpdateScreen = () => {
                             <View style={styles.sourceSelection}>
                                 <RadioButton.Group onValueChange={value => setHimaxSource(value as HimaxFirmwareSource)} value={himaxSource}>
                                     <View style={styles.radioRow}>
-                                        <RadioButton
+                                        <RadioButton.Android
                                             value="sdcard"
                                             disabled={!selectedOption.existsOnSd}
                                         />
@@ -470,7 +470,7 @@ export const FirmwareUpdateScreen = () => {
                                         </WWText>
                                     </View>
                                     <View style={styles.radioRow}>
-                                        <RadioButton
+                                        <RadioButton.Android
                                             value="download"
                                             disabled={!selectedOption.dbRecord}
                                         />


### PR DESCRIPTION
On iOS, react-native-paper's `Checkbox`/`RadioButton` render **nothing** when unselected — the "device is on USB / external power" confirmation and the "Use MANIFEST/… on SD" vs "Download from the cloud" source options appeared as bare text with a tick that materialises only after you guess where to tap. Switched to the `.Android` variants, which draw the outline box / radio circle on both platforms (visual change only; Android unchanged in practice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)