### PR TITLE
fix(ble): connection lifecycle - stuck console flag, stale auto-connect, blocking flush, status deadline

### DIFF
--- a/documentation/onboarding/05-DEVICE-FLOWS.md
+++ b/documentation/onboarding/05-DEVICE-FLOWS.md
@@ -1,5 +1,7 @@
 # Device Flows — Scanner Routing, Deployment, and Retrieval
 
+> BLE connection mechanics (scanners, auto-connect trust rules, failure signatures) live in [06-BLE-CONNECTIONS.md](./06-BLE-CONNECTIONS.md).
+
 User-facing device workflows covering the full deployment lifecycle: connect → configure → monitor → retrieve. For BLE commands, OP parameters, and hardware testing tools, see [04-ENGINEER-CONSOLE.md](./04-ENGINEER-CONSOLE.md).
 
 ---

--- a/documentation/onboarding/06-BLE-CONNECTIONS.md
+++ b/documentation/onboarding/06-BLE-CONNECTIONS.md
@@ -1,0 +1,71 @@
+# BLE Connections — Lifecycle, Gates, and Failure Signatures
+
+How the app discovers, connects to, and releases WW500 devices — and the
+sharp edges found on the bench (21 Jul 2026). Read alongside
+[04-ENGINEER-CONSOLE.md](./04-ENGINEER-CONSOLE.md) and
+[05-DEVICE-FLOWS.md](./05-DEVICE-FLOWS.md).
+
+## Two scanners, one flag
+
+| | Main scanner (Scanner tab) | Engineer Console connect dialog |
+|---|---|---|
+| Hook | `useDeviceDiscovery` + `useScanLoop` | `useEngineerConnect` + `useScanLoop` |
+| Session | 15 s countdown (`idle → active → expired`), manual restart | continuous while dialog open |
+| Auto-connect | yes — `useAutoConnectStateMachine` | no — user taps a device |
+
+`isEngineerConsoleActive` (redux `scanningSlice`) **disables the main
+scanner's scan loop and auto-connect** while the console's scanner runs.
+It is set when the console dialog opens and MUST be released on every exit
+path — it is cleared on successful navigation, explicit cancel, and (since
+`fix/ble-connection-lifecycle`) hook unmount. A stuck flag is invisible in
+the UI: the Scanner tab shows the searching animation but no scan bursts
+ever run.
+
+## Device-side facts that shape the app
+
+- The WW500 advertises **on wake and for a limited window after the
+  middle-button press** — not continuously. A sleeping device is silent.
+- The device drops the link itself (`RX: Disconnecting`) after BLE
+  inactivity, then sleeps. After ANY disconnect, assume it is asleep and
+  NOT advertising until woken (button / motion / timer).
+- iOS: `peripheral.id` is a phone-local CoreBluetooth UUID (never a MAC —
+  Android's id IS the MAC). Pending iOS connects never time out on their
+  own; every connect must carry an app-side timeout AND a cancel
+  (`BleManager.disconnect`) — `connectDevice` does this (13 s).
+- iOS silently drops write-without-response packets when its queue is full
+  — every write path uses write-with-response on iOS (PRs #213/#219).
+
+## Auto-connect trust rules (main scanner)
+
+A device is only auto-connected when ALL hold:
+1. Fresh advertisement **in this scan session** — `lastSeen` (stamped on
+   every advert) ≥ session start. A just-disconnected device lingers in
+   the cache but is asleep; connecting to it hangs (13 s) then alerts.
+2. Not `signalLost`, not connected, not loading.
+3. Auto-connect state machine allows it (`canAutoConnect`): failed
+   connects transition to `IGNORED_FOR_SESSION` (manual tap or "Search
+   Again" clears; `resetDevice` would loop — see PR #220).
+
+## Cache flushing
+
+`flushBleCache()` clears Redux devices and (Android) native-removes our
+cached peripherals. **The native removal blocks the Android scanner for
+10–60 s.** Callers racing a push-button advertising window pass
+`{ skipNativeRemoval: true }` (the Engineer Console does): otherwise the
+window expires before scanning starts, and discovery becomes
+order-dependent — "advertise, then open console" found nothing while
+"open console, then advertise" worked instantly.
+
+## Failure signatures (bench-verified)
+
+| Symptom | Cause | Status |
+|---|---|---|
+| "Pairing via Bluetooth…" forever with a UUID shown | pending iOS connect to a sleeping device + silent fall-through on failure | fixed (#220): timeout → alert → scanner |
+| Engineer Console dies moments after a command (iOS) | keepalive writes silently dropped → device idle-disconnects | fixed (#219): write-with-response |
+| Scanner tab "searches" forever, finds nothing | stuck `isEngineerConsoleActive` after leaving the console dialog | fixed: released on unmount |
+| Advertise-then-scan finds nothing; scan-then-advertise works | native cache flush blocks the Android scanner past the advertising window | fixed: console skips native removal |
+| Auto-connect to the device just disconnected from | stale cache entry trusted by auto-connect | fixed: `lastSeen` session gate |
+| Firmware Status spinner forever (iOS) | silent no-op when device not connected; no deadline on the check | fixed: error + 30 s deadline + pull-to-refresh |
+| Transfer dies mid-file (iOS), reason 0x8 | iOS stretches the conn interval; nRF fast-param request deferred and never retried | firmware fix: ww-hardware #30 (0.30.48) |
+
+*Last updated: 21 Jul 2026*

--- a/src/hooks/useBleListeners.tsx
+++ b/src/hooks/useBleListeners.tsx
@@ -183,6 +183,7 @@ export const useBleListeners = () => {
 				name: peripheral.name,
 				rssi: peripheral.rssi, // Copy RSSI value for signal strength display
 				signalLost: false,
+				lastSeen: Date.now(),
 			}
 
 			/**

--- a/src/hooks/useEngineerConnect.ts
+++ b/src/hooks/useEngineerConnect.ts
@@ -46,12 +46,14 @@ export const useEngineerConnect = () => {
         isConnectingRef.current = false
         setConnectingDevice(null)
         dispatch(setEngineerConsoleActive(true))
-        // Flush stale BLE state BEFORE enabling the scan loop.
-        // On Android, removePeripheral() inside flushBleCache blocks the
-        // BLE scanner for 10-60s. If we set dialogState='scanning' first,
-        // the scan loop starts while the cache is still being flushed,
-        // causing the first scan burst to find nothing.
-        await flushBleCache()
+        // Flush Redux state only. The native removePeripheral() pass blocks the
+        // Android scanner for 10-60s - long enough for the WW500's push-button
+        // advertising window to EXPIRE before scanning even starts, which made
+        // discovery order-dependent (advertise-then-open-console never found
+        // the device; console-first worked). A stale native GATT cache is the
+        // lesser evil: real adverts still arrive and the disconnect handler
+        // does per-device removal.
+        await flushBleCache({ skipNativeRemoval: true })
         setDialogState('scanning')
     }, [dispatch, flushBleCache])
 
@@ -116,6 +118,13 @@ export const useEngineerConnect = () => {
             setConnectingDevice(null)
         }
     }, [connectDevice, navigation, dispatch, stopScan])
+
+    // The console-active flag gates the MAIN scanner's scan loop and
+    // auto-connect. It was only cleared on successful navigation or explicit
+    // cancel - leaving any other way (back gesture, tab switch) left it stuck
+    // true, and the Scanner tab then 'searched' forever without actually
+    // scanning. Always release it on unmount.
+    useEffect(() => () => { dispatch(setEngineerConsoleActive(false)) }, [dispatch])
 
     // Reset state when dialog is dismissed / user cancels
     const reset = useCallback(() => {

--- a/src/hooks/useScanLoop.ts
+++ b/src/hooks/useScanLoop.ts
@@ -77,10 +77,10 @@ export const useScanLoop = ({ active, scanDfu = false }: UseScanLoopOptions) => 
      * cleanup that can block Android's BLE scanner for 10-60 seconds,
      * preventing advertisement delivery.
      */
-    const flushBleCache = useCallback(async () => {
+    const flushBleCache = useCallback(async (opts?: { skipNativeRemoval?: boolean }) => {
         dispatch(clearDiscoveredDevices())
 
-        if (Platform.OS === 'android') {
+        if (Platform.OS === 'android' && !opts?.skipNativeRemoval) {
             try {
                 const cached = await BleManager.getDiscoveredPeripherals()
                 const toRemove = cached.filter(p => {

--- a/src/redux/slices/devicesSlice.ts
+++ b/src/redux/slices/devicesSlice.ts
@@ -7,6 +7,7 @@ import { clearAllDeviceIntervals } from "../../utils/helpers"
 export type DeviceMetadata = any
 
 export interface ExtendedPeripheral extends Peripheral {
+	lastSeen?: number   // wall-clock ms of the most recent advertisement
 	connected: boolean
 	signalLost?: boolean
 	device: DeviceMetadata

--- a/src/screens/Devices/hooks/useDeviceDiscovery.ts
+++ b/src/screens/Devices/hooks/useDeviceDiscovery.ts
@@ -94,6 +94,12 @@ export const useDeviceDiscovery = (options?: UseDeviceDiscoveryOptions) => {
     const [scanSecondsRemaining, setScanSecondsRemaining] = useState(SCAN_DURATION_SECONDS)
     const [scanSessionId, setScanSessionId] = useState(0)
 
+    // Wall-clock start of the current scan session. Auto-connect only trusts
+    // devices whose advertisement arrived AFTER this: a just-disconnected
+    // device (e.g. leaving the Engineer Console) lingers in the cache but is
+    // asleep and not advertising - connecting to it just hangs.
+    const scanSessionStartRef = useRef(0)
+
     // ── Operation token for connection cleanup ──
     // Prevents stale async completions from corrupting state after navigation
     const operationIdRef = useRef(0)
@@ -142,6 +148,7 @@ export const useDeviceDiscovery = (options?: UseDeviceDiscoveryOptions) => {
         await flushBleCache()
 
         // 4. Reset/Increment session ID so that the countdown timer runs freshly
+        scanSessionStartRef.current = Date.now()
         setScanSessionId(prev => prev + 1)
         updateScanSessionState('active')
         setScanSecondsRemaining(SCAN_DURATION_SECONDS)
@@ -561,6 +568,8 @@ export const useDeviceDiscovery = (options?: UseDeviceDiscoveryOptions) => {
         if (isFocusedForAutoConnect && !isAnyDeviceConnecting && !isEngineerConsoleActive && scanSessionStateRef.current === 'active' && devicesToDisplay.length >= 1) {
             const deviceToConnect = devicesToDisplay.find(d =>
                 !d.signalLost && !d.connected && !d.loading && !processing && autoConnect.canAutoConnect(d.id)
+                    // fresh advert in THIS session - not a stale cache entry
+                    && (d.lastSeen ?? 0) >= scanSessionStartRef.current
             )
 
             if (deviceToConnect) {

--- a/src/screens/Devices/hooks/useFirmwareStatus.ts
+++ b/src/screens/Devices/hooks/useFirmwareStatus.ts
@@ -77,13 +77,26 @@ export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersi
     }, [])
 
     const checkStatus = useCallback(async () => {
-        if (!device?.connected) return
+        if (!device?.connected) {
+            // Never a silent no-op: this left the screen on its spinner forever
+            // when the device slept/disconnected before the check ran
+            setErrorMsg('Device not connected - wake it, reconnect via the scanner, then pull to refresh.')
+            return
+        }
 
         setIsChecking(true)
         setErrorMsg(null)
         hasRunActiveCheck.current = true
 
+        // Overall deadline: a hung network fetch or a BLE query whose response
+        // was lost previously left the screen on a spinner indefinitely
+        let deadlineTimer: ReturnType<typeof setTimeout> | undefined
+        const deadline = new Promise<never>((_, reject) => {
+            deadlineTimer = setTimeout(() => reject(new Error(
+                'Firmware status check timed out - the device may have gone to sleep. Wake it and pull to refresh.')), 30000)
+        })
         try {
+            await Promise.race([deadline, (async () => {
             // 1. Fetch Latest Cloud Versions
             const latestBle = await ReferenceDataService.getLatestFirmware('ble')
             const latestHimax = await ReferenceDataService.getLatestFirmware('himax')
@@ -147,6 +160,7 @@ export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersi
             })
 
             setLastChecked(new Date())
+            })()])
 
         } catch (error) {
             if (!isMounted.current) return
@@ -154,6 +168,7 @@ export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersi
             logError('[FirmwareStatus] Check failed:', error)
             setErrorMsg(msg)
         } finally {
+            clearTimeout(deadlineTimer)
             if (isMounted.current) {
                 setIsChecking(false)
             }

--- a/src/screens/Devices/hooks/useFirmwareStatus.ts
+++ b/src/screens/Devices/hooks/useFirmwareStatus.ts
@@ -91,12 +91,18 @@ export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersi
         // Overall deadline: a hung network fetch or a BLE query whose response
         // was lost previously left the screen on a spinner indefinitely
         let deadlineTimer: ReturnType<typeof setTimeout> | undefined
+        let timedOut = false
         const deadline = new Promise<never>((_, reject) => {
-            deadlineTimer = setTimeout(() => reject(new Error(
-                'Firmware status check timed out - the device may have gone to sleep. Wake it and pull to refresh.')), 30000)
+            deadlineTimer = setTimeout(() => {
+                timedOut = true
+                reject(new Error(
+                    'Firmware status check timed out - the device may have gone to sleep. Wake it and pull to refresh.'))
+            }, 30000)
         })
-        try {
-            await Promise.race([deadline, (async () => {
+        // The losing branch of the race keeps running: guard its state writes
+        // behind timedOut (a late success must not clobber the declared error)
+        // and swallow its late rejection (already reported via the race).
+        const work = (async () => {
             // 1. Fetch Latest Cloud Versions
             const latestBle = await ReferenceDataService.getLatestFirmware('ble')
             const latestHimax = await ReferenceDataService.getLatestFirmware('himax')
@@ -135,7 +141,7 @@ export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersi
                 logWarn('[FirmwareStatus] Failed to read Himax version:', e)
             }
 
-            if (!isMounted.current) return
+            if (!isMounted.current || timedOut) return
 
             // 3. Compute Outdated Flags (himax: variant-aware, see isHimaxOutdated)
             const bleOutdated = !!latestBle?.version && currentBleVersion !== latestBle.version
@@ -160,7 +166,10 @@ export function useFirmwareStatus({ device, initialBleVersion, initialHimaxVersi
             })
 
             setLastChecked(new Date())
-            })()])
+        })()
+        work.catch(() => {})
+        try {
+            await Promise.race([deadline, work])
 
         } catch (error) {
             if (!isMounted.current) return


### PR DESCRIPTION
## Bench-reported symptoms → root causes → fixes

| Symptom | Root cause | Fix |
|---|---|---|
| Scanner auto-connects to the device just disconnected from (e.g. after leaving Engineer Console) and hangs | auto-connect trusted any cached, non-signalLost device — the device is asleep and not advertising | `lastSeen` stamped on every advertisement; auto-connect requires a fresh advert **in the current scan session** |
| Scanner tab "searches" forever after visiting the Engineer Console | `isEngineerConsoleActive` gates the main scan loop and was only cleared on successful navigation or explicit cancel — back-gesture/tab-switch left it stuck | released on hook unmount |
| "Advertise, then open console" never finds the device; "console first, then advertise" connects instantly | `flushBleCache`'s native `removePeripheral` pass blocks the Android scanner 10–60 s — past the WW500's push-button advertising window | console path flushes Redux only (`skipNativeRemoval`); per-device native removal still happens in the disconnect handler |
| iOS stuck on Firmware Status spinner after preflight flagged an update | `checkStatus` silently no-opped when the device wasn't connected, and had no deadline for hung fetch/BLE queries | not-connected → visible error with instructions; whole check under a 30 s deadline surfacing to the existing error UI (pull-to-refresh retries) |

Also adds **documentation/onboarding/06-BLE-CONNECTIONS.md** — the two scanners and the console-active gate, device-side advertising/sleep facts, auto-connect trust rules, flush semantics, and a bench-verified failure-signature table (covering #219/#220/#221 and ww-hardware #30) — linked from 05-DEVICE-FLOWS.

## Testing
tsc clean; pre-commit related tests pass. Bench retest ask: (1) console → back-gesture out → Scanner tab must actually find devices; (2) advertise-button-first then console must connect; (3) leave console, Search for Devices — no auto-connect attempt to the sleeping device; (4) open Firmware Status with the device asleep — error message within 30 s, not a spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)