### PR TITLE
ci: enable PR-Agent AI code review

### DIFF
--- a/.github/workflows/pr-agent-review.yml
+++ b/.github/workflows/pr-agent-review.yml
@@ -1,0 +1,23 @@
+# PR-Agent code review (Gemini) — org starter workflow
+# Adds AI review to this repo: automatic on PR open, plus /review, /describe,
+# /improve and /ask commands in PR comments. Logic and house rules live in
+# wildlifeai/.github; this file just calls them. Docs: wildlifeai/.github/docs/pr-agent.md
+
+name: PR-Agent code review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    uses: wildlifeai/.github/.github/workflows/pr-agent.yml@main
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
Enables the org-wide PR-Agent review (reusable workflow in wildlifeai/.github; docs at wildlifeai/.github/docs/pr-agent.md).

- Automatic review + description when a PR opens (for PRs targeting dev, active as soon as this merges to dev)
- /review, /describe, /improve, /ask comment commands (activate once this reaches main, the default branch, with the next dev-to-main release)
- Uses the org GEMINI_API_KEY secret; model + house rules maintained centrally

Same enablement as https://github.com/wildlifeai/ww-backend/pull/151 (full URL used deliberately: PR-Agent parsed the earlier '#151' shorthand as this repo's issue 151 and ran an unrelated ticket-compliance check against it).